### PR TITLE
Feature/spherecasting and focus detection

### DIFF
--- a/Assets/Materials/BoxMaterial.mat
+++ b/Assets/Materials/BoxMaterial.mat
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 1
+  version: 2
 --- !u!21 &2100000
 Material:
   serializedVersion: 6
@@ -26,7 +26,7 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2050
+  m_CustomRenderQueue: 2000
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []

--- a/Assets/Prefabs/BasicPlayer.prefab
+++ b/Assets/Prefabs/BasicPlayer.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 2268735473202633543}
   - component: {fileID: -749921916936975090}
   - component: {fileID: 6982824905100499536}
+  - component: {fileID: -526833284236462530}
   m_Layer: 0
   m_Name: BasicPlayer
   m_TagString: Untagged
@@ -195,6 +196,28 @@ MonoBehaviour:
   syncInterval: 0.1
   pushPower: 10
   weight: 20
+--- !u!114 &-526833284236462530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245587927565386927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c1b1902a8c533a4e8f55a1a77e19d40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  sphereRadius: 0.1
+  viewDistance: 5
+  layerMask:
+    serializedVersion: 2
+    m_Bits: 0
+  cameraTransform: {fileID: 8130394144415267709}
+  focus: {fileID: 0}
+  currentHitDistance: 0
 --- !u!1 &886816266439757742
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Character/FocusDetection.cs
+++ b/Assets/Scripts/Character/FocusDetection.cs
@@ -39,16 +39,18 @@ namespace PropHunt.Character
                 return;
             }
             //Update origin -J
-            Vector3 origin =  cameraTransform.position;
+            Vector3 origin = cameraTransform.position;
             Vector3 direction = cameraTransform.forward;
             RaycastHit hit;
             //if spherecast hits something, update the player's focus and distance variables -J
-            if (Physics.SphereCast(origin,sphereRadius,direction,out hit, viewDistance)) {
+            if (Physics.SphereCast(origin, sphereRadius, direction, out hit, viewDistance))
+            {
                 focus = hit.transform.gameObject;
                 currentHitDistance = hit.distance;
             }
             //otherwise change the variables to the non-hit state -J
-            else {
+            else
+            {
                 focus = null;
                 currentHitDistance = viewDistance;
             }

--- a/Assets/Scripts/Character/FocusDetection.cs
+++ b/Assets/Scripts/Character/FocusDetection.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+///*make all triple slashes with summaries*
+namespace PropHunt.Character
+{
+    public class FocusDetection : NetworkBehaviour
+    {
+        /// <summary>
+        /// Network service for managing network calls
+        /// </summary>
+        public INetworkService networkService;
+
+        // How far can the player look
+        public float viewDistance = 5.0f;
+        // What direction is the player looking
+        public Transform cameraTransform;
+        // What the player is looking at
+        public GameObject focus;
+
+        // Start is called before the first frame update
+        public void Start()
+        {
+            this.networkService = new NetworkService(this);
+        }
+
+        // Update is called once per frame
+        public void Update()
+        {
+            if (!this.networkService.isLocalPlayer)
+            {
+                // exit from update if this is not the local player
+                return;
+            }
+            // Only upadte if IsLocalPlayer is true
+            // Do a sphere cast form where the player is looking this.viewDistance units forward in the
+            //   direction they are looking
+            // If they hit a game object
+            //    if it is the same as current focus, do nothing
+            //    if it is different, send a message "look at" to new object, update focus, send a message to old object "look away"
+            // If they did not hit anything
+            //    if focus was something previous frame, send "look away"
+        }
+    }
+}

--- a/Assets/Scripts/Character/FocusDetection.cs
+++ b/Assets/Scripts/Character/FocusDetection.cs
@@ -1,46 +1,59 @@
-﻿using System.Collections;
+﻿using Mirror;
+using PropHunt.Utils;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-///*make all triple slashes with summaries*
 namespace PropHunt.Character
 {
     public class FocusDetection : NetworkBehaviour
     {
-        /// <summary>
-        /// Network service for managing network calls
-        /// </summary>
+        /// <summary>Network service for managing network calls</summary>
         public INetworkService networkService;
-
-        // How far can the player look
+        ///<summary>Create sphere radius variable -J</summary>
+        public float sphereRadius;
+        /// <summary>Determines how far the player can look</summary>
         public float viewDistance = 5.0f;
-        // What direction is the player looking
+        ///<summary>Create layermask I guess -J</summary>
+        public LayerMask layerMask;
+        /// <summary>What direction is the player looking</summary>
         public Transform cameraTransform;
-        // What the player is looking at
+        /// <summary>What the player is looking at</summary>
         public GameObject focus;
+        /// <summary>How far away the hit from the spherecast is</summary>
+        public float currentHitDistance;
 
-        // Start is called before the first frame update
+        private Vector3 origin;
+        private Vector3 direction;
+
+        /// <summary> Start is called before the first frame update</summary>
         public void Start()
         {
             this.networkService = new NetworkService(this);
         }
 
-        // Update is called once per frame
+        /// <summary>Update is called once per frame</summary>
         public void Update()
         {
+            // Only upadte if IsLocalPlayer is true
             if (!this.networkService.isLocalPlayer)
             {
-                // exit from update if this is not the local player
+                /// exit from update if this is not the local player
                 return;
             }
-            // Only upadte if IsLocalPlayer is true
-            // Do a sphere cast form where the player is looking this.viewDistance units forward in the
-            //   direction they are looking
-            // If they hit a game object
-            //    if it is the same as current focus, do nothing
-            //    if it is different, send a message "look at" to new object, update focus, send a message to old object "look away"
-            // If they did not hit anything
-            //    if focus was something previous frame, send "look away"
+            //Update origin -J
+            origin =  cameraTransform.position;
+            direction = cameraTransform.forward;
+            RaycastHit hit;
+            if (Physics.SphereCast(origin,sphereRadius,direction,out hit, viewDistance)) {
+                //Update focus and distance variables of camera
+                focus = hit.transform.gameObject;
+                currentHitDistance = hit.distance;
+            }
+            else {
+                focus = null;
+                currentHitDistance = viewDistance;
+            }
         }
     }
 }

--- a/Assets/Scripts/Character/FocusDetection.cs
+++ b/Assets/Scripts/Character/FocusDetection.cs
@@ -23,9 +23,6 @@ namespace PropHunt.Character
         /// <summary>How far away the hit from the spherecast is</summary>
         public float currentHitDistance;
 
-        private Vector3 origin;
-        private Vector3 direction;
-
         /// <summary> Start is called before the first frame update</summary>
         public void Start()
         {
@@ -45,11 +42,12 @@ namespace PropHunt.Character
             origin =  cameraTransform.position;
             direction = cameraTransform.forward;
             RaycastHit hit;
+            //if spherecast hits something, update the player's focus and distance variables -J
             if (Physics.SphereCast(origin,sphereRadius,direction,out hit, viewDistance)) {
-                //Update focus and distance variables of camera
                 focus = hit.transform.gameObject;
                 currentHitDistance = hit.distance;
             }
+            //otherwise change the variables to the non-hit state -J
             else {
                 focus = null;
                 currentHitDistance = viewDistance;

--- a/Assets/Scripts/Character/FocusDetection.cs
+++ b/Assets/Scripts/Character/FocusDetection.cs
@@ -11,7 +11,7 @@ namespace PropHunt.Character
         /// <summary>Network service for managing network calls</summary>
         public INetworkService networkService;
         ///<summary>Create sphere radius variable -J</summary>
-        public float sphereRadius;
+        public float sphereRadius = 0.1f;
         /// <summary>Determines how far the player can look</summary>
         public float viewDistance = 5.0f;
         ///<summary>Create layermask I guess -J</summary>
@@ -39,8 +39,8 @@ namespace PropHunt.Character
                 return;
             }
             //Update origin -J
-            origin =  cameraTransform.position;
-            direction = cameraTransform.forward;
+            Vector3 origin =  cameraTransform.position;
+            Vector3 direction = cameraTransform.forward;
             RaycastHit hit;
             //if spherecast hits something, update the player's focus and distance variables -J
             if (Physics.SphereCast(origin,sphereRadius,direction,out hit, viewDistance)) {

--- a/Assets/Scripts/Character/FocusDetection.cs.meta
+++ b/Assets/Scripts/Character/FocusDetection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c1b1902a8c533a4e8f55a1a77e19d40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Character/FocusDetectionTests.cs
+++ b/Assets/Tests/EditMode/Character/FocusDetectionTests.cs
@@ -17,7 +17,7 @@ namespace Tests.Character
         /// <summary>
         /// Focus detection object being tested
         /// </summary>
-        FocusDetection  focusDetection;
+        FocusDetection focusDetection;
 
         /// <summary>
         /// Mock of network service attached to cameraFollow script

--- a/Assets/Tests/EditMode/Character/FocusDetectionTests.cs
+++ b/Assets/Tests/EditMode/Character/FocusDetectionTests.cs
@@ -1,0 +1,105 @@
+using Moq;
+using NUnit.Framework;
+using PropHunt.Character;
+using PropHunt.Utils;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests.Character
+{
+    /// <summary>
+    /// Tests to verify behaviour of focus detection script
+    /// </summary>
+    [TestFixture]
+    public class FocusDetectionTests
+    {
+        /// <summary>
+        /// Focus detection object being tested
+        /// </summary>
+        FocusDetection  focusDetection;
+
+        /// <summary>
+        /// Mock of network service attached to cameraFollow script
+        /// </summary>
+        Mock<INetworkService> networkServiceMock;
+
+        /// <summary>
+        /// What we want the player to look at
+        /// </summary>
+        GameObject focusTarget;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Setup a game object for our player
+            GameObject playerObject = new GameObject();
+            // Add a FocusDetection Behaviour to our object
+            this.focusDetection = playerObject.AddComponent<FocusDetection>();
+            this.focusDetection.Start();
+            // Setup the fields for the focus detection
+            // Setup and connect mocked network connection
+            this.networkServiceMock = new Mock<INetworkService>();
+            this.focusDetection.networkService = this.networkServiceMock.Object;
+            // Make player object it's own camera
+            this.focusDetection.cameraTransform = playerObject.transform;
+
+            // Setup thing for player to look at
+            focusTarget = new GameObject();
+            // Make it a box
+            BoxCollider box = focusTarget.AddComponent<BoxCollider>();
+            // Move it to position (0, 0, 2), which is 2 units in front of the player
+            box.transform.position = new Vector3(0, 0, 2);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Cleanup created game object
+            GameObject.DestroyImmediate(this.focusDetection.gameObject);
+            GameObject.DestroyImmediate(focusTarget);
+        }
+
+        [UnityTest]
+        public IEnumerator TestDoNothingIfNotLocal()
+        {
+            // Wait a frame to update the physics world and load colliders
+            yield return null;
+            this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(false);
+            this.focusDetection.Update();
+            // Make sure it didn't update to look at something
+            Assert.IsTrue(this.focusDetection.focus == null);
+        }
+
+        [UnityTest]
+        public IEnumerator TestLookingAtObject()
+        {
+            // Wait a frame to update the physics world and load colliders
+            yield return null;
+
+            RaycastHit hit;
+            bool isSomethingThere = Physics.SphereCast(new Vector3(0, 0, 0), 0.1f, new Vector3(0, 0, 1), out hit, 5.0f);
+            Debug.Log(isSomethingThere + " " + hit);
+
+            this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
+            this.focusDetection.Update();
+            // Make sure is looking at the box
+            Assert.IsTrue(this.focusDetection.focus == focusTarget);
+        }
+
+        [UnityTest]
+        public IEnumerator TestLookingAwayFromObject()
+        {
+            // Wait a frame to update the physics world and load colliders
+            yield return null;
+
+            this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
+            // rotate the player so they are looking away from the box
+            // rotate player 90 degrees to look away from box
+            this.focusDetection.transform.rotation = Quaternion.Euler(0, 90, 0);
+            this.focusDetection.Update();
+            // Make sure is looking at the box
+            Assert.IsTrue(this.focusDetection.focus == null);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Character/FocusDetectionTests.cs.meta
+++ b/Assets/Tests/EditMode/Character/FocusDetectionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd36106368043d442abe5d180b357651
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

Edited the Focus Detection script to detect focus's with the player's camera using Spherecasting. Updates attributes in the camera specifying the focus (part hit) and distance. Distance is up to 5 units away.

# How Has This Been Tested?

Tested in Unity, which shows the camera's focus attribute changing depending on the line of sight.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
