### PR TITLE
Removed some unnecessary complex flags from prop disguise behavior

### DIFF
--- a/Assets/Scripts/Prop/PropDisguise.cs
+++ b/Assets/Scripts/Prop/PropDisguise.cs
@@ -98,11 +98,7 @@ namespace PropHunt.Prop
             Collider currentCollider = gameObject.GetComponent<Collider>();
             if (currentCollider != null)
             {
-#if UNITY_EDITOR
-                GameObject.DestroyImmediate(currentCollider);
-#else
                 GameObject.Destroy(currentCollider);
-#endif
                 yield return null;
             }
             // Setup new collider data
@@ -114,11 +110,7 @@ namespace PropHunt.Prop
             // Clear out old disguise
             while (disguiseBase.childCount > 0)
             {
-#if UNITY_EDITOR
-                GameObject.DestroyImmediate(disguiseBase.GetChild(0).gameObject);
-#else
                 GameObject.Destroy(disguiseBase.GetChild(0).gameObject);
-#endif
                 yield return null;
             }
 

--- a/Assets/Tests/EditMode/Prop/PropDisguiseTests.cs
+++ b/Assets/Tests/EditMode/Prop/PropDisguiseTests.cs
@@ -81,6 +81,8 @@ namespace Tests.EditMode.Prop
             yield return null;
             UnityEngine.Debug.Log(propDisguise.transform.GetChild(0).name);
             Assert.IsTrue(propDisguise.transform.GetChild(0).name == disguises[0].disguiseVisual.name + "(Clone)");
+            GameObject testObject = new GameObject("testObj");
+            testObject.transform.parent = propDisguise.transform;
             propDisguise.selectedDisguise = "1";
             propDisguise.SetDisguise("0", "1");
             // Wait a frame for disguise to change


### PR DESCRIPTION
# Description

Removed some compiler flags (should have been from editor but it works fine for now as this shouldn't run in the editor). 

# How Has This Been Tested?

tested by verifying behavior and state of deletions for unit tests and in the game

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
