### PR TITLE
Fizzy Steamworks Duplicate Adjustment

### DIFF
--- a/Assets/Prefabs/Networking/FizzySteamworks.prefab
+++ b/Assets/Prefabs/Networking/FizzySteamworks.prefab
@@ -56,7 +56,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea368fb6f27ec2f40a40e20977992b9c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Channels: 02000000
+  Channels: 020000000200000002000000
   Timeout: 25
   SteamAppID: 480
   AllowSteamRelay: 1

--- a/Assets/Prefabs/Networking/NetworkManager.prefab
+++ b/Assets/Prefabs/Networking/NetworkManager.prefab
@@ -31,7 +31,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8542409671753137208}
-  m_RootOrder: 2
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &493852692511661025
 MonoBehaviour:
@@ -111,8 +111,6 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 3526196192005313034}
-  - {fileID: 3526196192389498835}
   - {fileID: 8139439411985088989}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -138,7 +136,7 @@ MonoBehaviour:
   serverBatchInterval: 0
   offlineScene: Assets/Scenes/MainMenu.unity
   onlineScene: 
-  transport: {fileID: 3526196192005313033}
+  transport: {fileID: 0}
   networkAddress: localhost
   maxConnections: 100
   disconnectInactiveConnections: 0
@@ -164,151 +162,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   currentMode: 1
-  kcpTransportSettings: {fileID: 3526196192005313033}
-  fizzySteamworksSettings: {fileID: 3526196192389498833}
---- !u!1001 &534699291906437109
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8542409671753137208}
-    m_Modifications:
-    - target: {fileID: 4000378363632139773, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_Name
-      value: KcpTransport
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
---- !u!4 &3526196192005313034 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4000378363632139775, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-  m_PrefabInstance: {fileID: 534699291906437109}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3526196192005313033 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4000378363632139772, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-  m_PrefabInstance: {fileID: 534699291906437109}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6b0fecffa3f624585964b0d0eb21b18e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &8238150148772232191
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8542409671753137208}
-    m_Modifications:
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4808816533550693423, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-      propertyPath: m_Name
-      value: FizzySteamworks
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
---- !u!4 &3526196192389498835 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4808816533550693420, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-  m_PrefabInstance: {fileID: 8238150148772232191}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3526196192389498833 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4808816533550693422, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
-  m_PrefabInstance: {fileID: 8238150148772232191}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea368fb6f27ec2f40a40e20977992b9c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  kcpTransportSettings: {fileID: 4000378363632139772, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
+  fizzySteamworksSettings: {fileID: 4808816533550693422, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -235,6 +235,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: NetworkManager
       objectReference: {fileID: 0}
+    - target: {fileID: 8542409671753137159, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
+      propertyPath: kcpTransportPrefab
+      value: 
+      objectReference: {fileID: 4000378363632139773, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
+    - target: {fileID: 8542409671753137159, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
+      propertyPath: fizzySteamworksPrefab
+      value: 
+      objectReference: {fileID: 4808816533550693423, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
     - target: {fileID: 8542409671753137208, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -279,7 +287,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -2805528078656427217, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
 --- !u!1001 &351090565
 PrefabInstance:

--- a/Assets/Scripts/UI/ToggleTransport.cs
+++ b/Assets/Scripts/UI/ToggleTransport.cs
@@ -77,6 +77,10 @@ namespace PropHunt.UI
             this.transportSettingsLookup[MultiplayerMode.KcpTransport].transform.parent = transform;
             this.transportSettingsLookup[MultiplayerMode.FizzySteamworks].transform.parent = transform;
 
+            // Set active state to false
+            this.transportSettingsLookup[MultiplayerMode.KcpTransport].gameObject.SetActive(false);
+            this.transportSettingsLookup[MultiplayerMode.FizzySteamworks].gameObject.SetActive(false);
+
             // Setup initial mode
             SetMultiplayerMode(this.currentMode, forceUpdate: true);
         }

--- a/Assets/Scripts/UI/ToggleTransport.cs
+++ b/Assets/Scripts/UI/ToggleTransport.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using kcp2k;
 using Mirror;
 using Mirror.FizzySteam;
+using PropHunt.Game.Flow;
 using PropHunt.Utils;
 using UnityEngine;
 
@@ -35,14 +36,14 @@ namespace PropHunt.UI
         public MultiplayerMode currentMode = MultiplayerMode.KcpTransport;
 
         /// <summary>
-        /// Settings selected for KcpTransport
+        /// Prefab of settings for KcpTransport
         /// </summary>
-        public KcpTransport kcpTransportSettings;
+        public GameObject kcpTransportPrefab;
 
         /// <summary>
-        /// Settings selected for FizzySteamworks
+        /// Prefab of settings for FizzySteamworks
         /// </summary>
-        public FizzySteamworks fizzySteamworksSettings;
+        public GameObject fizzySteamworksPrefab;
 
         /// <summary>
         /// Lookup from transport type to transport settings
@@ -56,17 +57,25 @@ namespace PropHunt.UI
 
         public void Start()
         {
-            // Set main instance
-            ToggleTransport.Instance = this;
+            if (ToggleTransport.Instance == null)
+            {
+                // Set main instance
+                ToggleTransport.Instance = this;
+            }
+            else
+            {
+                return;
+            }
 
             // setup a lookup table to link the currently available multiplayer modes
             //  to their enum type in code
             this.transportSettingsLookup = new Dictionary<MultiplayerMode, Transport>();
-            this.transportSettingsLookup[MultiplayerMode.FizzySteamworks] = this.fizzySteamworksSettings;
-            this.transportSettingsLookup[MultiplayerMode.KcpTransport] = this.kcpTransportSettings;
+            this.transportSettingsLookup[MultiplayerMode.FizzySteamworks] = GameObject.Instantiate(this.fizzySteamworksPrefab).GetComponent<FizzySteamworks>();
+            this.transportSettingsLookup[MultiplayerMode.KcpTransport] = GameObject.Instantiate(this.kcpTransportPrefab).GetComponent<KcpTransport>();
 
             // Un-parent fizzy steamworks because it leads to warning if not
-            this.fizzySteamworksSettings.transform.parent = null;
+            this.transportSettingsLookup[MultiplayerMode.KcpTransport].transform.parent = transform;
+            this.transportSettingsLookup[MultiplayerMode.FizzySteamworks].transform.parent = transform;
 
             // Setup initial mode
             SetMultiplayerMode(this.currentMode, forceUpdate: true);

--- a/Assets/Tests/EditMode/UI/ToggleTransportTests.cs
+++ b/Assets/Tests/EditMode/UI/ToggleTransportTests.cs
@@ -18,6 +18,9 @@ namespace Tests.EditMode.UI
         [Test]
         public void TestToggleTransportSettingsChanges()
         {
+#if UNITY_EDITOR
+            var scene = UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single);
+#endif
             // Create game object to hold our toggle transporter
             GameObject go = new GameObject();
             ToggleTransport toggle = go.AddComponent<ToggleTransport>();
@@ -44,21 +47,21 @@ namespace Tests.EditMode.UI
             toggle.Start();
 
             // Assert that the current mode matches the selected transport
-            Assert.IsTrue(Transport.activeTransport == kcpTransport);
+            Assert.IsTrue(Transport.activeTransport.GetComponent<KcpTransport>() != null);
 
             // Assert that the mode does not change when we update the mode to the current mode
             toggle.SetMultiplayerMode(toggle.currentMode);
-            Assert.IsTrue(Transport.activeTransport == kcpTransport);
+            Assert.IsTrue(Transport.activeTransport.GetComponent<KcpTransport>() != null);
 
             // Assert that mode can change when we chant to a new mode
             toggle.SetMultiplayerMode(MultiplayerMode.FizzySteamworks);
             Assert.IsTrue(toggle.currentMode == MultiplayerMode.FizzySteamworks);
-            Assert.IsTrue(Transport.activeTransport == fizzySteamworks);
+            Assert.IsTrue(Transport.activeTransport.GetComponent<FizzySteamworks>() != null);
 
             // Set multiplayer mode to KCP from string command
             toggle.SetMultiplayerMode(MultiplayerMode.KcpTransport, true);
             Assert.IsTrue(toggle.currentMode == MultiplayerMode.KcpTransport);
-            Assert.IsTrue(Transport.activeTransport == kcpTransport);
+            Assert.IsTrue(Transport.activeTransport.GetComponent<KcpTransport>() != null);
 
             // Cleanup created game objects
             GameObject.DestroyImmediate(go);

--- a/Assets/Tests/EditMode/UI/ToggleTransportTests.cs
+++ b/Assets/Tests/EditMode/UI/ToggleTransportTests.cs
@@ -35,10 +35,12 @@ namespace Tests.EditMode.UI
             FizzySteamworks fizzySteamworks = go.AddComponent<FizzySteamworks>();
 
             // Attach fake settings for transports to our toggle object
-            toggle.kcpTransportSettings = kcpTransport;
-            toggle.fizzySteamworksSettings = fizzySteamworks;
+            toggle.kcpTransportPrefab = kcpTransport.gameObject;
+            toggle.fizzySteamworksPrefab = fizzySteamworks.gameObject;
 
             // Test the start method for initial setup
+            toggle.Start();
+            // Test to ensure setup doesn't duplicate and cause errors
             toggle.Start();
 
             // Assert that the current mode matches the selected transport


### PR DESCRIPTION
# Description

Stopped duplication of fizzy steamworks whenever the game state is reset.

# How Has This Been Tested?

Tested locally with multiple clients as well as verifying it can still connect to steam.

(TODO: test to ensure connecting via steam id still works properly)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Closes #51 
