### PR TITLE
Fixing Highlight of Small Prop Items

### DIFF
--- a/Assets/Models/Small Items/Materials/Candle.mat
+++ b/Assets/Models/Small Items/Materials/Candle.mat
@@ -93,6 +93,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -105,15 +106,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -132,7 +133,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.9063317, g: 0.089403264, b: 0.19357064, a: 1}
     - _Color: {r: 0.745283, g: 0.69562095, b: 0.5800552, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Donut Icing.mat
+++ b/Assets/Models/Small Items/Materials/Donut Icing.mat
@@ -80,6 +80,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -91,15 +92,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -118,7 +119,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.9063317, g: 0.59091896, b: 0.8725255, a: 1}
     - _Color: {r: 0.8000001, g: 0.30805016, b: 0.73413545, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Donut.mat
+++ b/Assets/Models/Small Items/Materials/Donut.mat
@@ -93,6 +93,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -104,15 +105,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -131,7 +132,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.9063317, g: 0.7528206, b: 0.5051271, a: 1}
     - _Color: {r: 0.8000001, g: 0.52692646, b: 0.21881743, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Magic Bottle 2 Bottle.mat
+++ b/Assets/Models/Small Items/Materials/Magic Bottle 2 Bottle.mat
@@ -93,6 +93,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -104,15 +105,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -131,7 +132,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.23881087, g: 0.9063317, b: 0.8020086, a: 1}
     - _Color: {r: 0.04651115, g: 0.8000001, b: 0.6072375, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Magic Bottle 2 Lid.mat
+++ b/Assets/Models/Small Items/Materials/Magic Bottle 2 Lid.mat
@@ -93,6 +93,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -104,15 +105,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -131,7 +132,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0, g: 0, b: 0, a: 1}
     - _Color: {r: 0, g: 0, b: 0, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Magic Potion Bottle.mat
+++ b/Assets/Models/Small Items/Materials/Magic Potion Bottle.mat
@@ -93,6 +93,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -104,15 +105,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -131,7 +132,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.73681796, g: 0, b: 0.9063317, a: 1}
     - _Color: {r: 0.50222117, g: 0, b: 0.8000001, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Magic Potion Lid.mat
+++ b/Assets/Models/Small Items/Materials/Magic Potion Lid.mat
@@ -93,6 +93,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -104,15 +105,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -131,7 +132,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.9063317, g: 0, b: 0.29801545, a: 1}
     - _Color: {r: 0.8000001, g: 0, b: 0.07226019, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Soda Can Bottle.mat
+++ b/Assets/Models/Small Items/Materials/Soda Can Bottle.mat
@@ -97,6 +97,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -109,15 +110,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -136,7 +137,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.9063317, g: 0.089403264, b: 0.19357064, a: 1}
     - _Color: {r: 0.8000001, g: 0.008456275, b: 0.031136788, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Soda Can Lid.mat
+++ b/Assets/Models/Small Items/Materials/Soda Can Lid.mat
@@ -97,6 +97,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -109,15 +110,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -136,7 +137,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.9063317, g: 0.089403264, b: 0.19357064, a: 1}
     - _Color: {r: 0.33962262, g: 0.33962262, b: 0.33962262, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Models/Small Items/Materials/Wine Bottle.mat
+++ b/Assets/Models/Small Items/Materials/Wine Bottle.mat
@@ -93,6 +93,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - ColorOpacity: 1
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -104,15 +105,15 @@ Material:
     - _DetailNormalMapScale: 1
     - _DitherSize: 1
     - _DstBlend: 0
-    - _EmissionIntensity: 1
+    - _EmissionIntensity: 1.25
     - _EmissionIsActive: 0
     - _EnvironmentReflections: 1
-    - _FresnelValue: 0
+    - _FresnelValue: 2
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
-    - _HasHeartbeat: 0
-    - _HeartbeatFrequency: 0
+    - _HasHeartbeat: 1
+    - _HeartbeatFrequency: 3
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -131,7 +132,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.50332683, g: 0, b: 0.22356796, a: 1}
     - _Color: {r: 0.5849056, g: 0.013794942, b: 0.11763315, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Tiling: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/Prefabs/Props/Small Items/Donut Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Donut Prop.prefab
@@ -713,7 +713,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
 --- !u!65 &887287185
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Magic Potion 2 Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Magic Potion 2 Prop.prefab
@@ -114,7 +114,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
 --- !u!114 &5240101231465838114
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Magic Potion Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Magic Potion Prop.prefab
@@ -128,7 +128,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
 --- !u!114 &1421276817065654431
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Soda Can Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Soda Can Prop.prefab
@@ -128,7 +128,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
 --- !u!114 &5900986346319218575
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Wine Bottle Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Wine Bottle Prop.prefab
@@ -129,7 +129,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
 --- !u!114 &4400330216933705357
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Description

Committed a pull request to add small prop items that are transformable. 

# How Has This Been Tested?

This has been tested locally through the editor to ensure that colors load correctly when looking at the items. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Closes #60 
