### PR TITLE
Basic Player Ranged Attack

### DIFF
--- a/Assets/Materials/TestProp.mat
+++ b/Assets/Materials/TestProp.mat
@@ -20,7 +20,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: OtherBoxMaterial
+  m_Name: TestProp
   m_Shader: {fileID: -6465566751694194690, guid: b8a85e334e9beaa4da3566fc9e187173, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
@@ -149,7 +149,7 @@ Material:
     - Vector2_57A569B6: {r: 0, g: 0, b: 0, a: 0}
     - _AlbedoColor: {r: 1, g: 0.24754307, b: 0, a: 1}
     - _BaseColor: {r: 0.9150943, g: 0.331296, b: 0.11654504, a: 1}
-    - _Color: {r: 1, g: 0.5087234, b: 0, a: 1}
+    - _Color: {r: 0.9716981, g: 0.157634, b: 0.03208439, a: 1}
     - _Emission: {r: 0, g: 0, b: 0, a: 0}
     - _EmissionColor: {r: 0.8627451, g: 0.7058824, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Materials/TestProp.mat.meta
+++ b/Assets/Materials/TestProp.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 947ed5395f66fd140b5936e4b11cbbc6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Environment/TestCharacter Variant.prefab
+++ b/Assets/Prefabs/Environment/TestCharacter Variant.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1262777987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8327878735772046239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb864185cc1837e40a8b45affc6a65f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  playerId: 0
+  characterName: TestProp
+--- !u!114 &1262777988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8327878735772046239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79830135f57205c468671a3e44a7d6b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  playerTeam: 1
+--- !u!114 &1262777989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8327878735772046239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
+  compressRotation: 0
+  interpolateScale: 1
+  syncScale: 1
+--- !u!1001 &8242875181121786415
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 141303580758704560, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_Name
+      value: TestCharacter
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9141829
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.405302
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -47.820004
+      objectReference: {fileID: 0}
+    - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2435120839595836137, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: sceneId
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2435120839595836137, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5058026182699894294, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 947ed5395f66fd140b5936e4b11cbbc6, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+--- !u!1 &8327878735772046239 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 141303580758704560, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
+  m_PrefabInstance: {fileID: 8242875181121786415}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Environment/TestCharacter Variant.prefab
+++ b/Assets/Prefabs/Environment/TestCharacter Variant.prefab
@@ -31,27 +31,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   playerTeam: 1
---- !u!114 &1262777989
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8327878735772046239}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
-  compressRotation: 0
-  interpolateScale: 1
-  syncScale: 1
 --- !u!1001 &8242875181121786415
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -61,7 +40,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 141303580758704560, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
       propertyPath: m_Name
-      value: TestCharacter
+      value: TestCharacter Variant
       objectReference: {fileID: 0}
     - target: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Prefabs/Environment/TestCharacter Variant.prefab.meta
+++ b/Assets/Prefabs/Environment/TestCharacter Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad6181762396cf34ea1d7f1473816de3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Networking/NetworkManager.prefab
+++ b/Assets/Prefabs/Networking/NetworkManager.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 493852692511661025}
   - component: {fileID: 8195213029150407763}
   - component: {fileID: 7367678013483490725}
+  - component: {fileID: 6751860484789558292}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -82,6 +83,21 @@ MonoBehaviour:
   syncInterval: 0.1
   lobbyScene: Assets/Scenes/LobbyScene.unity
   gameScene: Assets/Scenes/BasicHouse.unity
+--- !u!114 &6751860484789558292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7297520795177474609}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c39ffd084b75bd444b3e7a53c449ae25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  respawnLocation: {x: 0, y: 0, z: 0}
 --- !u!1 &8542409671753137158
 GameObject:
   m_ObjectHideFlags: 0
@@ -162,5 +178,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   currentMode: 1
-  kcpTransportSettings: {fileID: 4000378363632139772, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-  fizzySteamworksSettings: {fileID: 4808816533550693422, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
+  kcpTransportPrefab: {fileID: 4000378363632139773, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
+  fizzySteamworksPrefab: {fileID: 4808816533550693423, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}

--- a/Assets/Prefabs/Player/BasicPlayer.prefab
+++ b/Assets/Prefabs/Player/BasicPlayer.prefab
@@ -28,6 +28,7 @@ GameObject:
   - component: {fileID: 5860327242025993134}
   - component: {fileID: 3584596455403864377}
   - component: {fileID: 623292108012484}
+  - component: {fileID: 5057111722928178139}
   m_Layer: 0
   m_Name: BasicPlayer
   m_TagString: Untagged
@@ -155,7 +156,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  cameraTransform: {fileID: 8130394144415267709}
+  cameraController: {fileID: 0}
+  audioListener: {fileID: 0}
 --- !u!114 &6982824905100499536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,7 +190,6 @@ MonoBehaviour:
   syncInterval: 0.1
   sphereRadius: 0.1
   viewDistance: 5
-  cameraTransform: {fileID: 8130394144415267709}
   focus: {fileID: 0}
   currentHitDistance: 0
   viewLayermask:
@@ -295,27 +296,28 @@ MonoBehaviour:
   groundedDistance: 0.01
   groundCheckDistance: 10
   maxWalkAngle: 60
-  maxBounces: 5
   gravity: {x: 0, y: -20, z: 0}
-  velocity: {x: 0, y: 0, z: 0}
-  jumpVelocity: 8
-  attemptingJump: 0
-  maxPushSpeed: 10
-  pushDecay: 0.9
-  anglePower: 1
-  verticalSnapDown: 0.45
-  onGround: 0
-  stepUpDepth: 0.05
-  verticalSnapUp: 0.35
-  distanceToGround: 0
-  surfaceNormal: {x: 0, y: 0, z: 0}
-  floor: {fileID: 0}
-  angle: 0
   movementSpeed: 5
   sprintSpeed: 7.5
+  jumpVelocity: 8
+  maxBounces: 5
+  pushDecay: 0.9
+  anglePower: 1
+  maxPushSpeed: 10
+  verticalSnapDown: 0.45
+  stepUpDepth: 0.05
+  verticalSnapUp: 0.35
+  snapBufferTime: 0.05
   inputMovement: {x: 0, y: 0, z: 0}
+  attemptingJump: 0
   isSprinting: 0
   elapsedFalling: 0
+  velocity: {x: 0, y: 0, z: 0}
+  distanceToGround: 0
+  onGround: 0
+  angle: 0
+  surfaceNormal: {x: 0, y: 0, z: 0}
+  floor: {fileID: 0}
 --- !u!114 &4965862787272249836
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -418,6 +420,25 @@ MonoBehaviour:
   minFootstepSoundDelay: 0.25
   soundType: 4
   footGrounded: {fileID: 6956521044681878227}
+--- !u!114 &5057111722928178139
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245587927565386927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: efdb34d87499d0a408ea83db2ac64efe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  attackCooldown: 0.1
+  raycastMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  targetTeam: 1
 --- !u!1 &886816266439757742
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Donut Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Donut Prop.prefab
@@ -55,6 +55,7 @@ MonoBehaviour:
   disguiseVisual: {fileID: 456060690911152005, guid: 645adfca45dfa0f46842067900f5c46c, type: 3}
   disguiseCollider: {fileID: 5049682125949965758, guid: f1dce1f9791ee2c43a0d7edfb6e725cf, type: 3}
   cameraOffset: {x: 0, y: 0, z: 0}
+  transformationMaterialSound: 5
 --- !u!114 &4938053258073102415
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -85,15 +86,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 4938053258073102404}
   clientAuthority: 0
   syncVelocity: 1
   clearVelocity: 0
-  velocitySensitivity: 0.1
+  velocitySensitivity: 0.05
   syncAngularVelocity: 1
   clearAngularVelocity: 0
-  angularVelocitySensitivity: 0.1
+  angularVelocitySensitivity: 0.05
 --- !u!114 &4938053258073102409
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -107,7 +108,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01

--- a/Assets/Prefabs/Props/Small Items/Magic Potion 2 Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Magic Potion 2 Prop.prefab
@@ -69,7 +69,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01
@@ -90,15 +90,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 5240101231465838115}
   clientAuthority: 0
   syncVelocity: 1
   clearVelocity: 0
-  velocitySensitivity: 0.1
+  velocitySensitivity: 0.05
   syncAngularVelocity: 1
   clearAngularVelocity: 0
-  angularVelocitySensitivity: 0.1
+  angularVelocitySensitivity: 0.05
 --- !u!54 &5240101231465838115
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -131,6 +131,7 @@ MonoBehaviour:
   disguiseVisual: {fileID: 6583999811884216055, guid: cc7ca3823a96a7b4b833191dca350d49, type: 3}
   disguiseCollider: {fileID: 5240101231465838143}
   cameraOffset: {x: 0, y: 0, z: 0}
+  transformationMaterialSound: 5
 --- !u!114 &5240101231465838113
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Magic Potion Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Magic Potion Prop.prefab
@@ -83,7 +83,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01
@@ -104,15 +104,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 1421276817065654430}
   clientAuthority: 0
   syncVelocity: 1
   clearVelocity: 0
-  velocitySensitivity: 0.1
+  velocitySensitivity: 0.05
   syncAngularVelocity: 1
   clearAngularVelocity: 0
-  angularVelocitySensitivity: 0.1
+  angularVelocitySensitivity: 0.05
 --- !u!54 &1421276817065654430
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Soda Can Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Soda Can Prop.prefab
@@ -83,7 +83,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01
@@ -104,15 +104,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 5900986346319218574}
   clientAuthority: 0
   syncVelocity: 1
   clearVelocity: 0
-  velocitySensitivity: 0.1
+  velocitySensitivity: 0.05
   syncAngularVelocity: 1
   clearAngularVelocity: 0
-  angularVelocitySensitivity: 0.1
+  angularVelocitySensitivity: 0.05
 --- !u!54 &5900986346319218574
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/Small Items/Wine Bottle Prop.prefab
+++ b/Assets/Prefabs/Props/Small Items/Wine Bottle Prop.prefab
@@ -84,7 +84,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01
@@ -105,15 +105,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 4400330216933705356}
   clientAuthority: 0
   syncVelocity: 1
   clearVelocity: 0
-  velocitySensitivity: 0.1
+  velocitySensitivity: 0.05
   syncAngularVelocity: 1
   clearAngularVelocity: 0
-  angularVelocitySensitivity: 0.1
+  angularVelocitySensitivity: 0.05
 --- !u!54 &4400330216933705356
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/TestProp/TestCapsuel.prefab
+++ b/Assets/Prefabs/Props/TestProp/TestCapsuel.prefab
@@ -104,7 +104,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 4678545534057497826}
   clientAuthority: 0
   syncVelocity: 1
@@ -772,7 +772,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01

--- a/Assets/Prefabs/Props/TestProp/TestCapsuel.prefab
+++ b/Assets/Prefabs/Props/TestProp/TestCapsuel.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 8738540330072658556}
   - component: {fileID: 1340223838}
   - component: {fileID: 375491870}
+  - component: {fileID: -3960626098327890882}
   m_Layer: 0
   m_Name: TestCapsuel
   m_TagString: Untagged
@@ -71,7 +72,8 @@ MonoBehaviour:
   propName: TestCapsule
   disguiseVisual: {fileID: 8009201142137579652, guid: 85a25f4fe2d924b4f8988b9ef1d26a38, type: 3}
   disguiseCollider: {fileID: 3398146232548734459}
-  cameraOffset: {fileID: 3290750543818525484}
+  cameraOffset: {x: 0, y: 0, z: 0}
+  transformationMaterialSound: 5
 --- !u!114 &2435120839595836137
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -757,6 +759,27 @@ MonoBehaviour:
     - {x: 0.7063923, y: 0.04494747, z: 0.706392}
     - {x: 0.34110048, y: 0.6646991, z: 0.6646996}
     - {x: 0.17692533, y: 0.69595146, z: 0.6959518}
+--- !u!114 &-3960626098327890882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141303580758704560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
+  compressRotation: 0
+  interpolateScale: 1
+  syncScale: 1
 --- !u!1 &6610165990005543099
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/TestProp/TestProp.prefab
+++ b/Assets/Prefabs/Props/TestProp/TestProp.prefab
@@ -196,7 +196,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 2418792549772054508}
   clientAuthority: 0
   syncVelocity: 1
@@ -275,7 +275,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01

--- a/Assets/Prefabs/Props/TestProp/TestProp.prefab
+++ b/Assets/Prefabs/Props/TestProp/TestProp.prefab
@@ -48,6 +48,7 @@ GameObject:
   - component: {fileID: 8058400921613398875}
   - component: {fileID: 1539371560}
   - component: {fileID: 1830657417}
+  - component: {fileID: -2257238741886337454}
   m_Layer: 0
   m_Name: TestProp
   m_TagString: Untagged
@@ -164,6 +165,7 @@ MonoBehaviour:
   disguiseVisual: {fileID: 5235849388726891487, guid: 9c4eb26a4149f7842bca9b647a0f2f32, type: 3}
   disguiseCollider: {fileID: 6464114997324751016}
   cameraOffset: {x: 0, y: 0, z: 0}
+  transformationMaterialSound: 5
 --- !u!114 &4663344245480376807
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -260,3 +262,24 @@ MonoBehaviour:
     - {x: 0.57735026, y: 0.57735026, z: -0.57735026}
     - {x: 0.57735026, y: 0.57735026, z: 0.57735026}
     - {x: 0.57735026, y: -0.57735026, z: 0.57735026}
+--- !u!114 &-2257238741886337454
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6956598771512216254}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
+  compressRotation: 0
+  interpolateScale: 1
+  syncScale: 1

--- a/Assets/Prefabs/Props/TestProp/TestSphere.prefab
+++ b/Assets/Prefabs/Props/TestProp/TestSphere.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 6956598772981576140}
   - component: {fileID: 1750258744}
   - component: {fileID: 1418625170}
+  - component: {fileID: -4835312065550775150}
   m_Layer: 0
   m_Name: TestSphere
   m_TagString: Untagged
@@ -71,7 +72,8 @@ MonoBehaviour:
   propName: TestSphere
   disguiseVisual: {fileID: 7768427415145440261, guid: 93ca935b4ae79f0419a388e0b61f3c41, type: 3}
   disguiseCollider: {fileID: 5172308136022080726}
-  cameraOffset: {fileID: 7425264745552991977}
+  cameraOffset: {x: 0, y: 0, z: 0}
+  transformationMaterialSound: 5
 --- !u!114 &535994576491328819
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -721,6 +723,27 @@ MonoBehaviour:
     - {x: -0.6959634, y: 0.1768332, z: -0.6959634}
     - {x: -0.34139428, y: 0.6646524, z: -0.66459554}
     - {x: -0.17685792, y: 0.6958694, z: -0.6960511}
+--- !u!114 &-4835312065550775150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2832051002949170794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
+  compressRotation: 0
+  interpolateScale: 1
+  syncScale: 1
 --- !u!1 &3026821061586071396
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Props/TestProp/TestSphere.prefab
+++ b/Assets/Prefabs/Props/TestProp/TestSphere.prefab
@@ -104,7 +104,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   target: {fileID: 7374360553800807224}
   clientAuthority: 0
   syncVelocity: 1
@@ -736,7 +736,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
-  syncInterval: 0.1
+  syncInterval: 0.05
   clientAuthority: 0
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01

--- a/Assets/Prefabs/UI/Screens/InGameHUD.prefab
+++ b/Assets/Prefabs/UI/Screens/InGameHUD.prefab
@@ -1,5 +1,41 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4763493927314187734
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4031690972677805778}
+  m_Layer: 5
+  m_Name: Crosshair
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4031690972677805778
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4763493927314187734}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3178446091601639072}
+  m_Father: {fileID: 6101108449083475880}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &6101108449083475876
 GameObject:
   m_ObjectHideFlags: 0
@@ -34,6 +70,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4387380406881394362}
+  - {fileID: 4031690972677805778}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -145,6 +182,81 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerInputState: 0
+--- !u!1 &8373712913536383167
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3178446091601639072}
+  - component: {fileID: 896966246963679549}
+  - component: {fileID: 5856599772460429064}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3178446091601639072
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8373712913536383167}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4031690972677805778}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &896966246963679549
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8373712913536383167}
+  m_CullTransparentMesh: 1
+--- !u!114 &5856599772460429064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8373712913536383167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: e0fab283653f7b149b836d8ddf61543b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &2041919405317290352
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -242,7 +354,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6108486980034106675, guid: de8522a1e9d09354e975135408a22560, type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7742637735198277325, guid: de8522a1e9d09354e975135408a22560, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scenes/BasicHouse.unity
+++ b/Assets/Scenes/BasicHouse.unity
@@ -19329,7 +19329,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8058400921613398875, guid: 19f5dcded63c2ff45b78f5bfb22ce1cb, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 19f5dcded63c2ff45b78f5bfb22ce1cb, type: 3}
 --- !u!4 &989705371 stripped
 Transform:
@@ -49418,7 +49419,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 2887522220232871823, guid: d892a98060df42d48972912d5ac17084, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: d892a98060df42d48972912d5ac17084, type: 3}
 --- !u!4 &5172308134285199266 stripped
 Transform:
@@ -49950,7 +49952,8 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 43af7b604365faf46825395d5dd0e183
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 1056656595796686933, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 43af7b604365faf46825395d5dd0e183, type: 3}
 --- !u!1001 &8894252815436151727
 PrefabInstance:

--- a/Assets/Scenes/BasicHouse.unity
+++ b/Assets/Scenes/BasicHouse.unity
@@ -1019,7 +1019,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24812
+  m_Name: pb_Mesh68616
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1183,7 +1183,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh25004
+  m_Name: pb_Mesh68808
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4066,7 +4066,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24204
+  m_Name: pb_Mesh68006
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4230,7 +4230,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23814
+  m_Name: pb_Mesh67616
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4394,7 +4394,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24986
+  m_Name: pb_Mesh68790
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4563,7 +4563,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24700
+  m_Name: pb_Mesh68504
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4727,7 +4727,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24220
+  m_Name: pb_Mesh68022
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -5611,7 +5611,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24362
+  m_Name: pb_Mesh68164
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -6421,7 +6421,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24880
+  m_Name: pb_Mesh68684
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -7201,7 +7201,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh25026
+  m_Name: pb_Mesh68830
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -7365,7 +7365,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24182
+  m_Name: pb_Mesh67984
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -8117,7 +8117,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24482
+  m_Name: pb_Mesh68284
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -8318,7 +8318,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23736
+  m_Name: pb_Mesh67538
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -8645,7 +8645,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24046
+  m_Name: pb_Mesh67848
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -9482,7 +9482,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24106
+  m_Name: pb_Mesh67908
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -10510,7 +10510,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24464
+  m_Name: pb_Mesh68266
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -10875,7 +10875,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh25112
+  m_Name: pb_Mesh68916
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11039,7 +11039,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24236
+  m_Name: pb_Mesh68038
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11667,7 +11667,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24624
+  m_Name: pb_Mesh68428
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11831,7 +11831,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23952
+  m_Name: pb_Mesh67754
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11995,7 +11995,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh25086
+  m_Name: pb_Mesh68890
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -13998,7 +13998,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24922
+  m_Name: pb_Mesh68726
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -14257,7 +14257,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24326
+  m_Name: pb_Mesh68128
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -14553,7 +14553,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23858
+  m_Name: pb_Mesh67660
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -14717,7 +14717,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23752
+  m_Name: pb_Mesh67554
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -15021,7 +15021,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24268
+  m_Name: pb_Mesh68070
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -15630,7 +15630,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24126
+  m_Name: pb_Mesh67928
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -15906,7 +15906,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24078
+  m_Name: pb_Mesh67880
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -19386,7 +19386,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24842
+  m_Name: pb_Mesh68646
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -20281,7 +20281,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24774
+  m_Name: pb_Mesh68578
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -20445,7 +20445,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24146
+  m_Name: pb_Mesh67948
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -23676,7 +23676,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24756
+  m_Name: pb_Mesh68560
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24103,7 +24103,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23988
+  m_Name: pb_Mesh67790
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24267,7 +24267,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23830
+  m_Name: pb_Mesh67632
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24431,7 +24431,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24684
+  m_Name: pb_Mesh68488
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24665,7 +24665,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24796
+  m_Name: pb_Mesh68600
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24829,7 +24829,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23894
+  m_Name: pb_Mesh67696
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -26344,7 +26344,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24432
+  m_Name: pb_Mesh68234
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -26491,170 +26491,6 @@ Mesh:
   m_LocalAABB:
     m_Center: {x: 11, y: -5, z: 29.2}
     m_Extent: {x: 7.9999995, y: 0, z: 5.8}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1342110856
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24740
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 6
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 4
-    localAABB:
-      m_Center: {x: -4, y: -5, z: 23.5}
-      m_Extent: {x: 6, y: 0, z: 6.5}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 000001000200010003000200
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 4
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 40
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 48
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 224
-    _typelessdata: 000020c10000a0c000008841000000000000803f000000000000803f0000000000000000000080bf000020c1000088410bd7a33c0bd7a33c000020c10000a0c00000f041000000000000803f000000000000803f0000000000000000000080bf000020c10000f0411a467b3f0bd7a33c000000400000a0c000008841000000000000803f000000000000803f0000000000000000000080bf00000040000088411fd7a33cb756683f000000400000a0c00000f041000000000000803f000000000000803f0000000000000000000080bf000000400000f0411a467b3fb756683f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -4, y: -5, z: 23.5}
-    m_Extent: {x: 6, y: 0, z: 6.5}
   m_MeshUsageFlags: 0
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
@@ -27068,6 +26904,170 @@ MonoBehaviour:
     LowFreqTransmission: 0
     MidFreqTransmission: 0
     HighFreqTransmission: 0
+--- !u!43 &1357256911
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh68544
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 6
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 4
+    localAABB:
+      m_Center: {x: -4, y: -5, z: 23.5}
+      m_Extent: {x: 6, y: 0, z: 6.5}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 000001000200010003000200
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 4
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 48
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 224
+    _typelessdata: 000020c10000a0c000008841000000000000803f000000000000803f0000000000000000000080bf000020c1000088410bd7a33c0bd7a33c000020c10000a0c00000f041000000000000803f000000000000803f0000000000000000000080bf000020c10000f0411a467b3f0bd7a33c000000400000a0c000008841000000000000803f000000000000803f0000000000000000000080bf00000040000088411fd7a33cb756683f000000400000a0c00000f041000000000000803f000000000000803f0000000000000000000080bf000000400000f0411a467b3fb756683f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -4, y: -5, z: 23.5}
+    m_Extent: {x: 6, y: 0, z: 6.5}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1001 &1365714733
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28429,7 +28429,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24644
+  m_Name: pb_Mesh68448
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -29012,7 +29012,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24416
+  m_Name: pb_Mesh68218
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -30189,7 +30189,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24564
+  m_Name: pb_Mesh68368
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -30404,7 +30404,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1586234349}
-  m_Mesh: {fileID: 1342110856}
+  m_Mesh: {fileID: 1357256911}
 --- !u!23 &1586234353
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -30508,7 +30508,7 @@ MonoBehaviour:
     m_AreaError: 15
   m_PreserveMeshAssetOnDestroy: 0
   assetGuid: 
-  m_Mesh: {fileID: 1342110856}
+  m_Mesh: {fileID: 1357256911}
   m_IsSelectable: 1
   m_SelectedFaces: 
   m_SelectedEdges: []
@@ -30547,7 +30547,7 @@ MeshCollider:
   serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30
-  m_Mesh: {fileID: 1342110856}
+  m_Mesh: {fileID: 1357256911}
 --- !u!1 &1601205135
 GameObject:
   m_ObjectHideFlags: 0
@@ -30999,7 +30999,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24896
+  m_Name: pb_Mesh68700
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -33319,7 +33319,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24010
+  m_Name: pb_Mesh67812
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -33483,7 +33483,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24062
+  m_Name: pb_Mesh67864
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34049,7 +34049,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23782
+  m_Name: pb_Mesh67584
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34213,7 +34213,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24948
+  m_Name: pb_Mesh68752
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34377,7 +34377,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24252
+  m_Name: pb_Mesh68054
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34893,7 +34893,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh25130
+  m_Name: pb_Mesh68934
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -35057,7 +35057,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24534
+  m_Name: pb_Mesh68338
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -37341,7 +37341,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24378
+  m_Name: pb_Mesh68180
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -38903,7 +38903,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24588
+  m_Name: pb_Mesh68392
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39112,7 +39112,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24518
+  m_Name: pb_Mesh68322
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39473,7 +39473,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23934
+  m_Name: pb_Mesh67736
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39637,7 +39637,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24970
+  m_Name: pb_Mesh68774
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -47167,7 +47167,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24858
+  m_Name: pb_Mesh68662
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -47739,7 +47739,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23798
+  m_Name: pb_Mesh67600
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -48067,7 +48067,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23918
+  m_Name: pb_Mesh67720
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -48469,7 +48469,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24604
+  m_Name: pb_Mesh68408
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2

--- a/Assets/Scenes/BasicHouse.unity
+++ b/Assets/Scenes/BasicHouse.unity
@@ -1019,7 +1019,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150142
+  m_Name: pb_Mesh24812
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1183,7 +1183,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150568
+  m_Name: pb_Mesh25004
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4066,7 +4066,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148842
+  m_Name: pb_Mesh24204
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4230,7 +4230,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh147998
+  m_Name: pb_Mesh23814
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4394,7 +4394,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150526
+  m_Name: pb_Mesh24986
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4563,7 +4563,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149858
+  m_Name: pb_Mesh24700
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4727,7 +4727,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148888
+  m_Name: pb_Mesh24220
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -5611,7 +5611,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149190
+  m_Name: pb_Mesh24362
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -6421,7 +6421,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150268
+  m_Name: pb_Mesh24880
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -7201,7 +7201,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150606
+  m_Name: pb_Mesh25026
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -7365,7 +7365,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148796
+  m_Name: pb_Mesh24182
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -8117,7 +8117,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149462
+  m_Name: pb_Mesh24482
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -8318,7 +8318,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh147906
+  m_Name: pb_Mesh23736
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -8645,7 +8645,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148466
+  m_Name: pb_Mesh24046
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -9482,7 +9482,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148596
+  m_Name: pb_Mesh24106
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -10510,7 +10510,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149412
+  m_Name: pb_Mesh24464
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -10875,7 +10875,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150770
+  m_Name: pb_Mesh25112
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11039,7 +11039,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148914
+  m_Name: pb_Mesh24236
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11667,7 +11667,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149670
+  m_Name: pb_Mesh24624
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11831,7 +11831,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148298
+  m_Name: pb_Mesh23952
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11995,7 +11995,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150744
+  m_Name: pb_Mesh25086
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -13998,7 +13998,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150386
+  m_Name: pb_Mesh24922
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -14257,7 +14257,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149090
+  m_Name: pb_Mesh24326
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -14553,7 +14553,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148096
+  m_Name: pb_Mesh23858
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -14717,7 +14717,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh147922
+  m_Name: pb_Mesh23752
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -15021,7 +15021,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148946
+  m_Name: pb_Mesh24268
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -15630,7 +15630,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148640
+  m_Name: pb_Mesh24126
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -15906,7 +15906,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148524
+  m_Name: pb_Mesh24078
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -19385,7 +19385,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150206
+  m_Name: pb_Mesh24842
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -20280,7 +20280,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150044
+  m_Name: pb_Mesh24774
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -20444,7 +20444,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148678
+  m_Name: pb_Mesh24146
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -20723,6 +20723,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9056124471848511986, guid: aef80c105fe8f524dae3993d5f72fd4c, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 309c46694339ded4ea6d37d58eda5b85, type: 2}
     - target: {fileID: 9056124471848511990, guid: aef80c105fe8f524dae3993d5f72fd4c, type: 3}
       propertyPath: sceneId
       value: 2724612529
@@ -23671,7 +23675,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150026
+  m_Name: pb_Mesh24756
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24098,7 +24102,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148350
+  m_Name: pb_Mesh23988
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24262,7 +24266,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148020
+  m_Name: pb_Mesh23830
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24426,7 +24430,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149834
+  m_Name: pb_Mesh24684
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24660,7 +24664,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150066
+  m_Name: pb_Mesh24796
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24824,7 +24828,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148220
+  m_Name: pb_Mesh23894
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24982,6 +24986,11 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!4 &1262777985 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+  m_PrefabInstance: {fileID: 8242875179900970159}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1269284571
 GameObject:
   m_ObjectHideFlags: 0
@@ -26334,7 +26343,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149300
+  m_Name: pb_Mesh24432
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -26498,7 +26507,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149982
+  m_Name: pb_Mesh24740
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -28419,7 +28428,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149738
+  m_Name: pb_Mesh24644
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -29002,7 +29011,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149284
+  m_Name: pb_Mesh24416
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -30179,7 +30188,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149594
+  m_Name: pb_Mesh24564
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -30989,7 +30998,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150284
+  m_Name: pb_Mesh24896
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -33309,7 +33318,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148416
+  m_Name: pb_Mesh24010
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -33473,7 +33482,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148504
+  m_Name: pb_Mesh24062
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34039,7 +34048,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh147960
+  m_Name: pb_Mesh23782
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34203,7 +34212,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150448
+  m_Name: pb_Mesh24948
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34367,7 +34376,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148930
+  m_Name: pb_Mesh24252
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34883,7 +34892,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150788
+  m_Name: pb_Mesh25130
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -35047,7 +35056,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149560
+  m_Name: pb_Mesh24534
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -37331,7 +37340,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149206
+  m_Name: pb_Mesh24378
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -38893,7 +38902,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149630
+  m_Name: pb_Mesh24588
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39092,6 +39101,7 @@ Transform:
   - {fileID: 989705371}
   - {fileID: 5172308134285199266}
   - {fileID: 8394092818034079348}
+  - {fileID: 1262777985}
   m_Father: {fileID: 994255477}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -39101,7 +39111,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149538
+  m_Name: pb_Mesh24518
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39462,7 +39472,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148272
+  m_Name: pb_Mesh23934
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39626,7 +39636,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150510
+  m_Name: pb_Mesh24970
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -47156,7 +47166,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh150222
+  m_Name: pb_Mesh24858
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -47728,7 +47738,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh147976
+  m_Name: pb_Mesh23798
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -48056,7 +48066,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh148256
+  m_Name: pb_Mesh23918
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -48458,7 +48468,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh149650
+  m_Name: pb_Mesh24604
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -49807,6 +49817,71 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d9ca16810519ad488949a711953b60e, type: 3}
+--- !u!1001 &8242875179900970159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1956078182}
+    m_Modifications:
+    - target: {fileID: 6030279002489819334, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: sceneId
+      value: 2964447288
+      objectReference: {fileID: 0}
+    - target: {fileID: 6030279002489819334, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_AssetId
+      value: ad6181762396cf34ea1d7f1473816de3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8327878735772046239, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_Name
+      value: TestCharacter
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9141829
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.405302
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -47.820004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9127344291571251088, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ad6181762396cf34ea1d7f1473816de3, type: 3}
 --- !u!4 &8394092818034079348 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 922749790837466559, guid: 43af7b604365faf46825395d5dd0e183, type: 3}

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -223,6 +223,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -2923298690912514389, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
+      propertyPath: transport
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 493852692511661025, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
       propertyPath: sceneId
       value: 1976774151
@@ -235,14 +239,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: NetworkManager
       objectReference: {fileID: 0}
-    - target: {fileID: 8542409671753137159, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
-      propertyPath: kcpTransportPrefab
-      value: 
-      objectReference: {fileID: 4000378363632139773, guid: f8b0771faa8c69e4fb6b86805ce52ee6, type: 3}
-    - target: {fileID: 8542409671753137159, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
-      propertyPath: fizzySteamworksPrefab
-      value: 
-      objectReference: {fileID: 4808816533550693423, guid: 9d70228972f0cd447b9d1c6122dbf8ae, type: 3}
     - target: {fileID: 8542409671753137208, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -287,8 +283,7 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: -2805528078656427217, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 128bf2dcaa8d43942a6e23d498102de3, type: 3}
 --- !u!1001 &351090565
 PrefabInstance:

--- a/Assets/Scripts/Character/CameraController.cs
+++ b/Assets/Scripts/Character/CameraController.cs
@@ -122,6 +122,18 @@ namespace PropHunt.Character
             this.currentDistance = minCameraDistance;
         }
 
+        public bool RaycastFromCameraBase(float maxDistance, LayerMask layerMask, QueryTriggerInteraction queryTriggerInteraction, out RaycastHit hit)
+        {
+            return PhysicsUtils.RaycastFirstHitIgnore(gameObject, CameraSource, cameraTransform.forward, maxDistance,
+                layerMask, queryTriggerInteraction, out hit);
+        }
+
+        public bool SpherecastFromCameraBase(float maxDistance, LayerMask layerMask, float sphereRadius, QueryTriggerInteraction queryTriggerInteraction, out RaycastHit hit)
+        {
+            return PhysicsUtils.SphereCastFirstHitIgnore(gameObject, CameraSource, sphereRadius, cameraTransform.forward, maxDistance,
+                layerMask, queryTriggerInteraction, out hit);
+        }
+
         public void Update()
         {
             if (!networkService.isLocalPlayer)

--- a/Assets/Scripts/Character/CharacterName.cs
+++ b/Assets/Scripts/Character/CharacterName.cs
@@ -129,7 +129,7 @@ namespace PropHunt.Character
 
         public void Start()
         {
-            if (networkService.isServer)
+            if (networkService.isServer && connectionToClient != null)
             {
                 playerId = connectionToClient.connectionId;
             }

--- a/Assets/Scripts/Character/FocusDetection.cs
+++ b/Assets/Scripts/Character/FocusDetection.cs
@@ -40,17 +40,17 @@ namespace PropHunt.Character
         /// What the player is looking at
         /// </summary>
         public GameObject focus;
-    
+
         /// <summary>
         /// How far away the hit from the spherecast is
         /// </summary>
         public float currentHitDistance;
-    
+
         /// <summary>
         /// What does view interaction able to hit
         /// </summary>
         public LayerMask viewLayermask = ~0;
-    
+
         /// <summary>
         /// How does view intearaction interact with triggers
         /// </summary>

--- a/Assets/Scripts/Character/FocusDetection.cs
+++ b/Assets/Scripts/Character/FocusDetection.cs
@@ -5,31 +5,62 @@ using UnityEngine;
 
 namespace PropHunt.Character
 {
+    /// <summary>
+    /// Detect what the player is currently looking at
+    /// </summary>
+    [RequireComponent(typeof(CameraController))]
     public class FocusDetection : NetworkBehaviour
     {
-        /// <summary>Unity service for getting player inputs</summary>
+        /// <summary>
+        /// Unity service for getting player inputs
+        /// </summary>
         public IUnityService unityService = new UnityService();
-        /// <summary>Network service for managing network calls</summary>
+
+        /// <summary>
+        /// Network service for managing network calls
+        /// </summary>
         public INetworkService networkService;
-        ///<summary>Create sphere radius variable -J</summary>
+
+        /// <summary>
+        /// Create sphere radius variable -J
+        /// </summary>
         public float sphereRadius = 0.1f;
-        /// <summary>Determines how far the player can look</summary>
+
+        /// <summary>
+        /// Determines how far the player can look
+        /// </summary>
         public float viewDistance = 5.0f;
-        /// <summary>What direction is the player looking</summary>
-        public Transform cameraTransform;
-        /// <summary>What the player is looking at</summary>
+
+        /// <summary>
+        /// Controller that operates the player camera
+        /// </summary>
+        private CameraController cameraController;
+
+        /// <summary>
+        /// What the player is looking at
+        /// </summary>
         public GameObject focus;
-        /// <summary>How far away the hit from the spherecast is</summary>
+    
+        /// <summary>
+        /// How far away the hit from the spherecast is
+        /// </summary>
         public float currentHitDistance;
-        /// <summary>What does view interaction able to hit</summary>
+    
+        /// <summary>
+        /// What does view interaction able to hit
+        /// </summary>
         public LayerMask viewLayermask = ~0;
-        /// <summary>How does view intearaction interact with triggers</summary>
+    
+        /// <summary>
+        /// How does view intearaction interact with triggers
+        /// </summary>
         public QueryTriggerInteraction focusTriggerInteraction;
 
         /// <summary> Start is called before the first frame update</summary>
         public void Start()
         {
             this.networkService = new NetworkService(this);
+            this.cameraController = GetComponent<CameraController>();
         }
 
         public void InteractWithObject(GameObject target, GameObject source)
@@ -63,13 +94,9 @@ namespace PropHunt.Character
                 // exit from update if this is not the local player
                 return;
             }
-            //Update origin -J
-            Vector3 origin = cameraTransform.position;
-            Vector3 direction = cameraTransform.forward;
-            RaycastHit hit;
             // if spherecast hits something, update the player's focus and distance variables -J
-            if (PhysicsUtils.SphereCastFirstHitIgnore(gameObject, origin, sphereRadius, direction, focusRange,
-                viewLayermask, focusTriggerInteraction, out hit))
+            if (controller.SpherecastFromCameraBase(focusRange,
+                viewLayermask, sphereRadius, focusTriggerInteraction, out RaycastHit hit))
             {
                 focus = hit.transform.gameObject;
                 // If the object has a focus component, tell the object it is 'focused'

--- a/Assets/Scripts/Combat.meta
+++ b/Assets/Scripts/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3de464675668bc4eb7239acd0b479b9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/BasicRangedAttack.cs
+++ b/Assets/Scripts/Combat/BasicRangedAttack.cs
@@ -28,6 +28,13 @@ namespace PropHunt.Combat
         private LayerMask raycastMask = ~0;
 
         /// <summary>
+        /// Radius of attack made by player
+        /// </summary>
+        [Tooltip("Radius of attack when casting sphere in front of player")]
+        [SerializeField]
+        private float attackRadius = 0.05f;
+
+        /// <summary>
         /// The team this player can make ranged attacks upon
         /// </summary>
         [Tooltip("Which team this player can shoot at")]
@@ -72,7 +79,7 @@ namespace PropHunt.Combat
         /// </summary>
         /// <returns></returns>
         public bool GetTarget(out RaycastHit hit) =>
-            cameraController.RaycastFromCameraBase(Mathf.Infinity, raycastMask, QueryTriggerInteraction.Ignore, out hit);
+            cameraController.SpherecastFromCameraBase(Mathf.Infinity, raycastMask, attackRadius, QueryTriggerInteraction.Ignore, out hit);
 
         /// <summary>
         /// Command to attack a given game object. Hit object should be computed client side
@@ -97,7 +104,7 @@ namespace PropHunt.Combat
         public void Update()
         {
             // Assert that the player has a target
-            if (networkService.isLocalPlayer && unityService.GetButtonDown("Fire1") && CanAttack)
+            if (PlayerInputManager.playerMovementState == PlayerInputState.Allow && networkService.isLocalPlayer && unityService.GetButtonDown("Fire1") && CanAttack)
             {
                 GetTarget(out RaycastHit hit);
                 GameObject target = null;

--- a/Assets/Scripts/Combat/BasicRangedAttack.cs
+++ b/Assets/Scripts/Combat/BasicRangedAttack.cs
@@ -104,7 +104,8 @@ namespace PropHunt.Combat
         public void Update()
         {
             // Assert that the player has a target
-            if (PlayerInputManager.playerMovementState == PlayerInputState.Allow && networkService.isLocalPlayer && unityService.GetButtonDown("Fire1") && CanAttack)
+            if (PlayerInputManager.playerMovementState == PlayerInputState.Allow &&
+                networkService.isLocalPlayer && unityService.GetButtonDown("Fire1") && CanAttack)
             {
                 GetTarget(out RaycastHit hit);
                 GameObject target = null;

--- a/Assets/Scripts/Combat/BasicRangedAttack.cs
+++ b/Assets/Scripts/Combat/BasicRangedAttack.cs
@@ -1,0 +1,133 @@
+using Mirror;
+using PropHunt.Character;
+using PropHunt.Environment.Sound;
+using PropHunt.Utils;
+using UnityEngine;
+
+namespace PropHunt.Combat
+{
+    /// <summary>
+    /// Basic ranged attack for a character
+    /// </summary>
+    [RequireComponent(typeof(CameraController))]
+    public class BasicRangedAttack : NetworkBehaviour
+    {
+        /// <summary>
+        /// Cooldown between character attacks
+        /// </summary>
+        [Tooltip("Time in seconds between character attacks")]
+        [SerializeField]
+        private float attackCooldown = 0.1f;
+
+        /// <summary>
+        /// Layer mask for player aim and what the player can hit. By default this will
+        /// collide with all layers.
+        /// </summary>
+        [Tooltip("What layers should the player aim intersect with when detecting aim")]
+        [SerializeField]
+        private LayerMask raycastMask = ~0;
+
+        /// <summary>
+        /// The team this player can make ranged attacks upon
+        /// </summary>
+        [Tooltip("Which team this player can shoot at")]
+        [SerializeField]
+        private Team targetTeam = Team.Prop;
+
+        /// <summary>
+        /// Time of previous character attack
+        /// </summary>
+        private float previousAttack = Mathf.NegativeInfinity;
+
+        /// <summary>
+        /// Unity service for getting time and input commands
+        /// </summary>
+        public IUnityService unityService = new UnityService();
+
+        /// <summary>
+        /// Network service for checking network state
+        /// </summary>
+        public INetworkService networkService;
+
+        /// <summary>
+        /// Camera controller for getting player focus and aim
+        /// </summary>
+        private CameraController cameraController;
+
+        /// <summary>
+        /// Can the player attack right now? This is based off the previous attack
+        /// cooldown and the current time
+        /// </summary>
+        /// <returns>True if the player can attack, false otherwise</returns>
+        public bool CanAttack => (unityService.time - previousAttack) >= attackCooldown;
+
+        public void Start()
+        {
+            networkService = new NetworkService(this);
+            this.cameraController = GetComponent<CameraController>();
+        }
+
+        /// <summary>
+        /// Gets target of what the player is currently looking at. Will use the raycast 
+        /// </summary>
+        /// <returns></returns>
+        public bool GetTarget(out RaycastHit hit) =>
+            cameraController.RaycastFromCameraBase(Mathf.Infinity, raycastMask, QueryTriggerInteraction.Ignore, out hit);
+
+        /// <summary>
+        /// Command to attack a given game object. Hit object should be computed client side
+        /// as the lag between client and server could lead to misunderstood errors.
+        /// A future check could be added to ensure that the player is not shooting through
+        /// walls or around corners to discourage errors or cheating.
+        /// </summary>
+        /// <param name="hitObject">Object that the player is attacking</param>
+        [Server]
+        private void Attack(GameObject hitObject)
+        {
+            previousAttack = unityService.time;
+            // Play an attack sound
+            SoundEffectManager.CreateNetworkedSoundEffectAtPoint(transform.position, SoundMaterial.Misc, SoundType.Attack);
+            // null object means the player fired and missed
+            if (hitObject != null)
+            {
+                CombatManager.Attack(gameObject, hitObject);
+            }
+        }
+
+        public void Update()
+        {
+            // Assert that the player has a target
+            if (networkService.isLocalPlayer && unityService.GetButtonDown("Fire1") && CanAttack)
+            {
+                GetTarget(out RaycastHit hit);
+                GameObject target = null;
+                // Check if the target has a player team component
+                // If the player team is the target team, then attack the player
+                PlayerTeam team = null;
+                if (hit.collider != null &&
+                    (team = hit.collider.gameObject.GetComponent<PlayerTeam>()) != null &&
+                    team.playerTeam == targetTeam)
+                {
+                    target = hit.collider.gameObject;
+                }
+
+                // If the player can attack
+                if (networkService.isServer)
+                {
+                    Attack(target);
+                }
+                else
+                {
+                    previousAttack = unityService.time;
+                    CmdAttackAction(target);
+                }
+            }
+        }
+
+        [Command]
+        public void CmdAttackAction(GameObject hitObject)
+        {
+            Attack(hitObject);
+        }
+    }
+}

--- a/Assets/Scripts/Combat/BasicRangedAttack.cs.meta
+++ b/Assets/Scripts/Combat/BasicRangedAttack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efdb34d87499d0a408ea83db2ac64efe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/CombatManager.cs
+++ b/Assets/Scripts/Combat/CombatManager.cs
@@ -1,0 +1,48 @@
+
+using System;
+using UnityEngine;
+
+namespace PropHunt.Combat
+{
+    /// <summary>
+    /// Events that describe a player attack
+    /// </summary>
+    public class PlayerAttackEvent : EventArgs
+    {
+        /// <summary>
+        /// Player attacking (source is attacking target)
+        /// </summary>
+        public GameObject source;
+        /// <summary>
+        /// Target of the attack
+        /// </summary>
+        public GameObject target;
+    }
+
+    /// <summary>
+    /// Static combat manager class for managing various combat events and actions that may occur during a game
+    /// </summary>
+    public static class CombatManager
+    {
+        /// <summary>
+        /// Event that is invoked whenever a player is attacked by another player.
+        /// Normally this should only be invoked on the server as attack actions, health, and various
+        /// attrbitues should be handled by the server.
+        /// </summary>
+        public static event EventHandler<PlayerAttackEvent> OnPlayerAttack;
+
+        /// <summary>
+        /// Invoke when one player successfully attacks another player
+        /// </summary>
+        /// <param name="source">PLayer starting the attack</param>
+        /// <param name="target">Player being attacked</param>
+        public static void Attack(GameObject source, GameObject target)
+        {
+            PlayerAttackEvent attackEvent = new PlayerAttackEvent();
+            attackEvent.source = source;
+            attackEvent.target = target;
+
+            OnPlayerAttack?.Invoke(source, attackEvent);
+        }
+    }
+}

--- a/Assets/Scripts/Combat/CombatManager.cs
+++ b/Assets/Scripts/Combat/CombatManager.cs
@@ -1,5 +1,8 @@
 
 using System;
+using Mirror;
+using PropHunt.Character;
+using PropHunt.Game.Communication;
 using UnityEngine;
 
 namespace PropHunt.Combat

--- a/Assets/Scripts/Combat/CombatManager.cs.meta
+++ b/Assets/Scripts/Combat/CombatManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63eba229365d0494c85844b81dc7f4ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/PlayerRespawnManager.cs
+++ b/Assets/Scripts/Combat/PlayerRespawnManager.cs
@@ -41,7 +41,7 @@ namespace PropHunt.Combat
             CharacterName targetName = attack.target.GetComponent<CharacterName>();
 
             DebugChatLog.SendChatMessage(new ChatMessage("", $"Player {sourceName.characterName} attacked {targetName.characterName}"));
-            SoundEffectManager.CreateNetworkedSoundEffectAtPoint(targetName.transform.position, SoundMaterial.Misc, SoundType.Death, 
+            SoundEffectManager.CreateNetworkedSoundEffectAtPoint(targetName.transform.position, SoundMaterial.Misc, SoundType.Death,
                 UnityEngine.Random.Range(0.8f, 1.2f));
 
             attack.target.transform.position = respawnLocation;

--- a/Assets/Scripts/Combat/PlayerRespawnManager.cs
+++ b/Assets/Scripts/Combat/PlayerRespawnManager.cs
@@ -1,0 +1,51 @@
+
+using System;
+using Mirror;
+using PropHunt.Character;
+using PropHunt.Environment.Sound;
+using PropHunt.Game.Communication;
+using UnityEngine;
+
+namespace PropHunt.Combat
+{
+    /// <summary>
+    /// Class to manage player respawn events
+    /// </summary>
+    public class PlayerRespawnManager : NetworkBehaviour
+    {
+        /// <summary>
+        /// Player respawn location when they are attacked
+        /// </summary>
+        [Tooltip("Location in which player respans when they are attacked")]
+        [SerializeField]
+        private Vector3 respawnLocation;
+
+        public override void OnStartServer()
+        {
+            CombatManager.OnPlayerAttack += HandlePlayerAttack;
+        }
+
+        public void OnDisable()
+        {
+            CombatManager.OnPlayerAttack -= HandlePlayerAttack;
+        }
+
+        public void OnDestroy()
+        {
+            CombatManager.OnPlayerAttack -= HandlePlayerAttack;
+        }
+
+        public void HandlePlayerAttack(object source, PlayerAttackEvent attack)
+        {
+            CharacterName sourceName = attack.source.GetComponent<CharacterName>();
+            CharacterName targetName = attack.target.GetComponent<CharacterName>();
+
+            DebugChatLog.SendChatMessage(new ChatMessage("", $"Player {sourceName.characterName} attacked {targetName.characterName}"));
+            SoundEffectManager.CreateNetworkedSoundEffectAtPoint(targetName.transform.position, SoundMaterial.Misc, SoundType.Death, 
+                UnityEngine.Random.Range(0.8f, 1.2f));
+
+            attack.target.transform.position = respawnLocation;
+            attack.target.transform.rotation = Quaternion.identity;
+        }
+    }
+}

--- a/Assets/Scripts/Combat/PlayerRespawnManager.cs.meta
+++ b/Assets/Scripts/Combat/PlayerRespawnManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c39ffd084b75bd444b3e7a53c449ae25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Environment/Sound/SoundEffectLibrary.cs
+++ b/Assets/Scripts/Environment/Sound/SoundEffectLibrary.cs
@@ -213,6 +213,7 @@ namespace PropHunt.Environment.Sound
         Misc,
         PropTransformation,
         Attack,
+        Death,
     }
 
     /// <summary>

--- a/Assets/Scripts/Environment/Sound/SoundEffectLibrary.cs
+++ b/Assets/Scripts/Environment/Sound/SoundEffectLibrary.cs
@@ -212,6 +212,7 @@ namespace PropHunt.Environment.Sound
         Footstep,
         Misc,
         PropTransformation,
+        Attack,
     }
 
     /// <summary>

--- a/Assets/Sound/SFX/Misc/SFX_Polymorph_Liquids.wav.meta
+++ b/Assets/Sound/SFX/Misc/SFX_Polymorph_Liquids.wav.meta
@@ -7,7 +7,7 @@ AudioImporter:
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
-    compressionFormat: 0
+    compressionFormat: 2
     quality: 1
     conversionMode: 0
   platformSettingOverrides:

--- a/Assets/Sound/SFX/Misc/SFX_Poof.wav.meta
+++ b/Assets/Sound/SFX/Misc/SFX_Poof.wav.meta
@@ -7,7 +7,7 @@ AudioImporter:
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
-    compressionFormat: 0
+    compressionFormat: 2
     quality: 1
     conversionMode: 0
   platformSettingOverrides:
@@ -25,7 +25,7 @@ AudioImporter:
       compressionFormat: 1
       quality: 1
       conversionMode: 0
-  forceToMono: 0
+  forceToMono: 1
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0

--- a/Assets/Sound/SFX/Misc/death-sound.mp3
+++ b/Assets/Sound/SFX/Misc/death-sound.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4a7b93b3d89a1daba7e6fc06220eb1b6adbcd40ee2b81def3cb11cc930020c2
+size 3290

--- a/Assets/Sound/SFX/Misc/death-sound.mp3.meta
+++ b/Assets/Sound/SFX/Misc/death-sound.mp3.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 95da4cabe0518404d96c3260d334910f
+guid: 9a043ec5a138c3f459a455dd7fd63d24
 AudioImporter:
   externalObjects: {}
   serializedVersion: 6
@@ -25,7 +25,7 @@ AudioImporter:
       compressionFormat: 1
       quality: 1
       conversionMode: 0
-  forceToMono: 0
+  forceToMono: 1
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0

--- a/Assets/Sound/SFXLibrary.asset
+++ b/Assets/Sound/SFXLibrary.asset
@@ -34,7 +34,7 @@ MonoBehaviour:
     audioClip: {fileID: 8300000, guid: 9dd1be827a78f2c43a56140282bb1d39, type: 3}
     soundId: scrape-glass-test-1
   - soundMaterial: 5
-    soundType: 5
+    soundType: 7
     audioClip: {fileID: 8300000, guid: 8ca4436d0750ae743a654bf87ce0643e, type: 3}
     soundId: sfx-poof
   - soundMaterial: 5

--- a/Assets/Sound/SFXLibrary.asset
+++ b/Assets/Sound/SFXLibrary.asset
@@ -45,3 +45,7 @@ MonoBehaviour:
     soundType: 6
     audioClip: {fileID: 8300000, guid: 62aca13de6d2ea84aabbdd16c8ef5b5d, type: 3}
     soundId: SFX-polymorph-LIquids
+  - soundMaterial: 5
+    soundType: 8
+    audioClip: {fileID: 8300000, guid: 9a043ec5a138c3f459a455dd7fd63d24, type: 3}
+    soundId: SFX-Death-Sound

--- a/Assets/Tests/EditMode/Character/CameraControllerTests.cs
+++ b/Assets/Tests/EditMode/Character/CameraControllerTests.cs
@@ -71,6 +71,14 @@ namespace Tests.EditMode.Character
         }
 
         [Test]
+        public void TestCameraRaycastFromBase()
+        {
+            RaycastHit hit;
+            Assert.IsFalse(this.cameraController.RaycastFromCameraBase(Mathf.Infinity, ~0, QueryTriggerInteraction.Ignore, out hit));
+            Assert.IsFalse(this.cameraController.SpherecastFromCameraBase(Mathf.Infinity, ~0, 0.1f, QueryTriggerInteraction.Ignore, out hit));
+        }
+
+        [Test]
         public void TestVariousDitherThresholds()
         {
             this.cameraController.maxCameraDistance = 2.0f;

--- a/Assets/Tests/EditMode/Character/FocusDetectionTests.cs
+++ b/Assets/Tests/EditMode/Character/FocusDetectionTests.cs
@@ -70,6 +70,7 @@ namespace Tests.EditMode.Character
             // Setup a game object for our player
             GameObject playerObject = new GameObject();
             // Add a FocusDetection Behaviour to our object
+            CameraController controller = playerObject.AddComponent<CameraController>();
             this.focusDetection = playerObject.AddComponent<FocusDetection>();
             this.focusDetection.Start();
             // Setup the fields for the focus detection
@@ -79,7 +80,7 @@ namespace Tests.EditMode.Character
             this.focusDetection.networkService = this.networkServiceMock.Object;
             this.focusDetection.unityService = this.unityServiceMock.Object;
             // Make player object it's own camera
-            this.focusDetection.cameraTransform = playerObject.transform;
+            controller.cameraTransform = playerObject.transform;
 
             // Setup thing for player to look at
             focusTarget = new GameObject();

--- a/Assets/Tests/EditMode/Combat.meta
+++ b/Assets/Tests/EditMode/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 400ec889bd50bb54c9f13c0e271fa499
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Combat/BasicRangedAttackTests.cs
+++ b/Assets/Tests/EditMode/Combat/BasicRangedAttackTests.cs
@@ -1,0 +1,152 @@
+using Mirror.Tests.RemoteAttributeTest;
+using Moq;
+using NUnit.Framework;
+using PropHunt.Character;
+using PropHunt.Combat;
+using PropHunt.Utils;
+using System.Collections;
+using Tests.EditMode.Game.Flow;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests.EditMode.Combat
+{
+    /// <summary>
+    /// Tests to verify behaviour of basic ranged attack
+    /// </summary>
+    [TestFixture]
+    public class BasicRangedAttackTests : CustomNetworkManagerTestBase
+    {
+        BasicRangedAttack attack;
+
+        Mock<INetworkService> networkServiceMock;
+
+        Mock<IUnityService> unityServiceMock;
+
+        GameObject attackTarget;
+
+        int attackCount = 0;
+
+        public void CountAttack(object sender, PlayerAttackEvent attackEvent) => attackCount++;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            reloadScene = false;
+            base.SetUp();
+        }
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+#if UNITY_EDITOR
+            var scene = UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene,
+                UnityEditor.SceneManagement.NewSceneMode.Single);
+#endif
+            // Count attacks made by player
+            CombatManager.OnPlayerAttack += CountAttack;
+            attackCount = 0;
+
+            // Allow player attacks
+            PlayerInputManager.playerMovementState = PlayerInputState.Allow;
+
+            // Setup a game object for our player
+            GameObject playerObject = new GameObject();
+            playerObject.name = "player";
+            // Add a FocusDetection Behaviour to our object
+            CameraController controller = playerObject.AddComponent<CameraController>();
+            this.attack = playerObject.AddComponent<BasicRangedAttack>();
+            this.attack.Start();
+            // Setup the fields for the basic ranged attack
+            // Setup and connect mocked network connection
+            this.networkServiceMock = new Mock<INetworkService>();
+            this.unityServiceMock = new Mock<IUnityService>();
+            this.attack.networkService = this.networkServiceMock.Object;
+            this.attack.unityService = this.unityServiceMock.Object;
+            // Make player object it's own camera
+            controller.cameraTransform = playerObject.transform;
+
+            // Setup thing for player to look at
+            attackTarget = new GameObject();
+            // Make it a box
+            BoxCollider box = attackTarget.AddComponent<BoxCollider>();
+            // Add a character team and other info to the target
+            attackTarget.AddComponent<CharacterName>();
+            attackTarget.AddComponent<PlayerTeam>().playerTeam = Team.Prop;
+            // Move it to position (0, 0, 2), which is 2 units in front of the player
+            box.transform.position = new Vector3(0, 0, 2);
+            attackTarget.name = "Box";
+
+            yield return null;
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            // Cleanup created game object
+            GameObject.DestroyImmediate(this.attack.gameObject);
+            GameObject.DestroyImmediate(attackTarget);
+
+            CombatManager.OnPlayerAttack -= CountAttack;
+        }
+
+        [Test]
+        public void TestDoNothingIfNotLocal()
+        {
+            this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(false);
+            this.attack.Update();
+        }
+
+        [Test]
+        public void TestAttackCooldownTiming()
+        {
+            this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
+            this.networkServiceMock.Setup(e => e.isServer).Returns(true);
+            this.unityServiceMock.Setup(e => e.time).Returns(0);
+            // Assert that we can attack at start
+            Assert.IsTrue(this.attack.CanAttack);
+            // Attempt to attack, then assert that cooldown has kicked in
+            this.unityServiceMock.Setup(e => e.GetButtonDown("Fire1")).Returns(true);
+            this.attack.Update();
+            Assert.IsTrue(attackCount == 1);
+            Assert.IsFalse(this.attack.CanAttack);
+        }
+    }
+
+    /// <summary>
+    /// Tests to verify behaviour of commands in focus detection object
+    /// </summary>
+    [TestFixture]
+    public class BasicRangedAttackCommandTests : RemoteTestBase
+    {
+        [UnityTest]
+        public IEnumerator TestVerifyAttackNotServer()
+        {
+            PlayerInputManager.playerMovementState = PlayerInputState.Allow;
+            Mock<INetworkService> networkServiceMock = new Mock<INetworkService>();
+            Mock<IUnityService> unityServiceMock = new Mock<IUnityService>();
+
+            BasicRangedAttack attack = CreateHostObject<BasicRangedAttack>(true);
+
+            attack.Start();
+            attack.GetComponent<CameraController>().cameraTransform = attack.gameObject.transform;
+
+            attack.networkService = networkServiceMock.Object;
+            attack.unityService = unityServiceMock.Object;
+
+            networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
+            networkServiceMock.Setup(e => e.isServer).Returns(false);
+            unityServiceMock.Setup(e => e.time).Returns(0);
+            yield return null;
+            // Assert that we can attack at start
+            Assert.IsTrue(attack.CanAttack);
+            // Attempt to attack, then assert that cooldown has kicked in
+            unityServiceMock.Setup(e => e.GetButtonDown("Fire1")).Returns(true);
+            attack.Update();
+
+            yield return null;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Combat/BasicRangedAttackTests.cs.meta
+++ b/Assets/Tests/EditMode/Combat/BasicRangedAttackTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7965c25649ebdcd4a8904c5f22726ae7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Combat/RespawnManagerTests.cs
+++ b/Assets/Tests/EditMode/Combat/RespawnManagerTests.cs
@@ -1,0 +1,55 @@
+
+using System.Linq;
+using NUnit.Framework;
+using PropHunt.Character;
+using PropHunt.Combat;
+using PropHunt.Environment.Sound;
+using Tests.EditMode.Environment.Sound;
+using UnityEditor;
+using UnityEngine;
+
+namespace Tests.EditMode.Combat
+{
+    /// <summary>
+    /// Tests to verify behaviour of respawn manager
+    /// </summary>
+    [TestFixture]
+    public class RespawnManagerTests : SoundEffectManagerTestBase
+    {
+        [Test]
+        public void RespawnPlayerOnAttacked()
+        {
+            // Setup a basic death sound effect
+            library.sounds = library.sounds.Concat(new LabeledSFX[]{
+                new LabeledSFX
+                {
+                    soundMaterial = SoundMaterial.Misc,
+                    soundType = SoundType.Death,
+                    audioClip = AssetDatabase.LoadAssetAtPath<AudioClip>("Assets/Sound/SFX/Hits/glass-hit-1.wav"),
+                    soundId = "testSound1",
+                }
+            }).ToArray();
+            library.ClearLookups();
+            library.SetupLookups();
+
+            // Setup respawn manager
+            PlayerRespawnManager respawnManager = new GameObject().AddComponent<PlayerRespawnManager>();
+            respawnManager.OnStartServer();
+
+            // Create a test player attacker and attacked
+            GameObject player = new GameObject();
+            player.AddComponent<CharacterName>();
+            // Handle a player attack and their respawn
+            PlayerAttackEvent attackEvent = new PlayerAttackEvent();
+            attackEvent.source = player;
+            attackEvent.target = player;
+
+            respawnManager.HandlePlayerAttack(attackEvent.source, attackEvent);
+
+            // Cleanup from test
+            respawnManager.OnDisable();
+            respawnManager.OnDestroy();
+            GameObject.DestroyImmediate(respawnManager.gameObject);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Combat/RespawnManagerTests.cs.meta
+++ b/Assets/Tests/EditMode/Combat/RespawnManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7942a2f86f820054d8c9e45c1ccc5309
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Game/Flow/CustomNetworkManagerTests.cs
+++ b/Assets/Tests/EditMode/Game/Flow/CustomNetworkManagerTests.cs
@@ -12,11 +12,17 @@ namespace Tests.EditMode.Game.Flow
     {
         protected CustomNetworkManager networkManager;
 
+        protected bool reloadScene = true;
+
         [SetUp]
         public virtual void SetUp()
         {
 #if UNITY_EDITOR
-            var scene = UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single);
+            if (reloadScene)
+            {
+                var scene = UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene,
+                    UnityEditor.SceneManagement.NewSceneMode.Single);
+            }
 #endif
             GameObject go = new GameObject();
             Transport.activeTransport = go.AddComponent<MemoryTransport>();

--- a/Assets/Textures/crosshair.png
+++ b/Assets/Textures/crosshair.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fedb6890be19a4932818b9893a44744d8affb718af7d16b907a7b685e6d5dd05
+size 645

--- a/Assets/Textures/crosshair.png.meta
+++ b/Assets/Textures/crosshair.png.meta
@@ -1,0 +1,156 @@
+fileFormatVersion: 2
+guid: e0fab283653f7b149b836d8ddf61543b
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: 2
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 8192
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 8192
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 8192
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 8192
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 8192
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 8192
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

Added a basic player ranged attack to the game. 

This is a simple ranged attack that casts a ray (client side) from a player to see what it comes into contact with. If the ray hits a *prop*, then this is an attack and the prop is sent back to respawn and a message is logged to the debug chat (This could be improved with another feed in the top left of the UI later). 

# How Has This Been Tested?

This has been tested through unit tests, creating a local npc that can be attacked, and by creating multiple clients locally as well as clients over the internet. These tests verified the behaviour of the attacks and attempted to identify any future improvements. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
