### PR TITLE
Adding Sound Reflections

### DIFF
--- a/Assets/Prefabs/Sound/SoundEffectTemplate.prefab
+++ b/Assets/Prefabs/Sound/SoundEffectTemplate.prefab
@@ -55,10 +55,10 @@ MonoBehaviour:
   sourceRadius: 1
   occlusionSamples: 4
   directMixLevel: 1
-  reflections: 0
+  reflections: 1
   indirectBinaural: 0
   physicsBasedAttenuationForIndirect: 0
-  indirectMixLevel: 1
+  indirectMixLevel: 0.5
   simulationType: 0
   uniqueIdentifier: 
   avoidSilenceDuringInit: 1

--- a/Assets/Scenes/BasicHouse.unity
+++ b/Assets/Scenes/BasicHouse.unity
@@ -28834,7 +28834,7 @@ MonoBehaviour:
     LowFreqTransmission: 0.1
     MidFreqTransmission: 0.05
     HighFreqTransmission: 0.03
-  simulationPreset: 0
+  simulationPreset: 3
   simulationValue:
     MaxOcclusionSamples: 128
     RealtimeRays: 4096
@@ -28845,9 +28845,9 @@ MonoBehaviour:
     BakeSecondaryRays: 4096
     BakeBounces: 32
     BakeThreadsPercentage: 5
-    Duration: 1
+    Duration: 0.1
     AmbisonicsOrder: 1
-    MaxSources: 32
+    MaxSources: 128
     IrradianceMinDistance: 1
   updateComponents: 1
   currentAudioListener: {fileID: 0}
@@ -49485,7 +49485,7 @@ MonoBehaviour:
   sourceRadius: 1
   occlusionSamples: 4
   directMixLevel: 1
-  reflections: 0
+  reflections: 1
   indirectBinaural: 0
   physicsBasedAttenuationForIndirect: 1
   indirectMixLevel: 0.5

--- a/Assets/Scenes/LobbyScene.unity
+++ b/Assets/Scenes/LobbyScene.unity
@@ -519,7 +519,7 @@ MonoBehaviour:
     LowFreqTransmission: 0.1
     MidFreqTransmission: 0.05
     HighFreqTransmission: 0.03
-  simulationPreset: 0
+  simulationPreset: 3
   simulationValue:
     MaxOcclusionSamples: 128
     RealtimeRays: 4096
@@ -530,9 +530,9 @@ MonoBehaviour:
     BakeSecondaryRays: 4096
     BakeBounces: 32
     BakeThreadsPercentage: 5
-    Duration: 1
+    Duration: 0.1
     AmbisonicsOrder: 1
-    MaxSources: 32
+    MaxSources: 128
     IrradianceMinDistance: 1
   updateComponents: 1
   currentAudioListener: {fileID: 0}

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -448,7 +448,7 @@ MonoBehaviour:
     LowFreqTransmission: 0.1
     MidFreqTransmission: 0.05
     HighFreqTransmission: 0.03
-  simulationPreset: 0
+  simulationPreset: 3
   simulationValue:
     MaxOcclusionSamples: 128
     RealtimeRays: 4096
@@ -459,9 +459,9 @@ MonoBehaviour:
     BakeSecondaryRays: 4096
     BakeBounces: 32
     BakeThreadsPercentage: 5
-    Duration: 1
+    Duration: 0.1
     AmbisonicsOrder: 1
-    MaxSources: 32
+    MaxSources: 128
     IrradianceMinDistance: 1
   updateComponents: 1
   currentAudioListener: {fileID: 0}

--- a/Assets/Sound/Settings/AudioMixer.mixer
+++ b/Assets/Sound/Settings/AudioMixer.mixer
@@ -66,24 +66,6 @@ AudioMixerEffectController:
   m_SendTarget: {fileID: 0}
   m_EnableWetMix: 0
   m_Bypass: 0
---- !u!244 &-93144897322839728
-AudioMixerEffectController:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_EffectID: a860e7ddb1991fd45a419b3d916b1357
-  m_EffectName: Steam Audio Mixer Return
-  m_MixLevel: 8c5dc146d9d08ab45938306f6dec4263
-  m_Parameters:
-  - m_ParameterName: Binaural
-    m_GUID: a29a9811910ca684fab2c57477d60e2a
-  - m_ParameterName: BypassAtInit
-    m_GUID: 463dcc841f088bf4280fccbceafad89d
-  m_SendTarget: {fileID: 0}
-  m_EnableWetMix: 0
-  m_Bypass: 0
 --- !u!241 &24100000
 AudioMixerController:
   m_ObjectHideFlags: 0
@@ -136,7 +118,6 @@ AudioMixerGroupController:
   m_Effects:
   - {fileID: 24400004}
   - {fileID: 5377644287383961196}
-  - {fileID: -93144897322839728}
   m_UserColorIndex: 0
   m_Mute: 0
   m_Solo: 0


### PR DESCRIPTION
# Description

Changed sound reflection duration to minimum value to allow for sounds to propagate without overloading the computing power. 

# How Has This Been Tested?

Tested on the server as well as locally with multiple clients to ensure sound reflections are heard on one client when another client walks around. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
