### PR TITLE
Changed screens for UIManager to use canvas groups instead of canvas

### DIFF
--- a/Assets/Prefabs/UI/Screens/ConnectingMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/ConnectingMenu.prefab
@@ -142,14 +142,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5674224039144228347}
-  - component: {fileID: 5674224039144228346}
-  - component: {fileID: 5674224039144228345}
-  - component: {fileID: 5674224039144228344}
   - component: {fileID: 3564265319080918651}
   - component: {fileID: -3259061909783027214}
-  - component: {fileID: -6075487917269459594}
-  - component: {fileID: -5758259788360720994}
   - component: {fileID: 332710742900957262}
+  - component: {fileID: 1397598960152374926}
   m_Layer: 5
   m_Name: ConnectingMenu
   m_TagString: Untagged
@@ -166,7 +162,7 @@ RectTransform:
   m_GameObject: {fileID: 5674224039144228343}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5323720090524091789}
   - {fileID: 2628041358880679826}
@@ -175,71 +171,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &5674224039144228346
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5674224039144228343}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &5674224039144228345
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5674224039144228343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!114 &5674224039144228344
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5674224039144228343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!114 &3564265319080918651
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -267,48 +202,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cursorLockMode: 0
   cursorVisible: 1
---- !u!114 &-6075487917269459594
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5674224039144228343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &-5758259788360720994
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5674224039144228343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &332710742900957262
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: -5758259788360720994}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -403,6 +296,18 @@ MonoBehaviour:
   m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &1397598960152374926
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5674224039144228343}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &7587180217208483878
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Screens/CreditsScreen.prefab
+++ b/Assets/Prefabs/UI/Screens/CreditsScreen.prefab
@@ -637,14 +637,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6637053135914170324}
-  - component: {fileID: 6637053135914170325}
-  - component: {fileID: 6637053135914170326}
-  - component: {fileID: 6637053135914170327}
   - component: {fileID: 8387962290575963714}
   - component: {fileID: 2165199262839015779}
-  - component: {fileID: 1946592893505652272}
-  - component: {fileID: -3437185461780715288}
   - component: {fileID: 4503478779792694836}
+  - component: {fileID: -5140422447409558950}
   m_Layer: 5
   m_Name: CreditsScreen
   m_TagString: Untagged
@@ -661,7 +657,7 @@ RectTransform:
   m_GameObject: {fileID: 6637053135914170328}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 883047728937022666}
   - {fileID: 5146796209057648483}
@@ -669,71 +665,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &6637053135914170325
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 1
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &6637053135914170326
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!114 &6637053135914170327
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!114 &8387962290575963714
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -762,48 +697,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cursorLockMode: 0
   cursorVisible: 1
---- !u!114 &1946592893505652272
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &-3437185461780715288
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &4503478779792694836
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -818,7 +711,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: -3437185461780715288}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -910,6 +803,18 @@ MonoBehaviour:
   m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &-5140422447409558950
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6637053135914170328}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &7015566759992716889
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Screens/InGameHUD.prefab
+++ b/Assets/Prefabs/UI/Screens/InGameHUD.prefab
@@ -45,15 +45,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6101108449083475880}
-  - component: {fileID: 6101108449083475881}
-  - component: {fileID: 3677147509884030994}
-  - component: {fileID: 6101108449083475882}
   - component: {fileID: 6496672550345548457}
   - component: {fileID: 1292730286106825495}
   - component: {fileID: 1811976908144868216}
-  - component: {fileID: -8767646246911753318}
-  - component: {fileID: -5346662837639526377}
   - component: {fileID: 8446500240076052195}
+  - component: {fileID: 4795890211778059004}
   m_Layer: 5
   m_Name: InGameHUD
   m_TagString: Untagged
@@ -70,7 +66,7 @@ RectTransform:
   m_GameObject: {fileID: 6101108449083475876}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4387380406881394362}
   - {fileID: 4031690972677805778}
@@ -78,71 +74,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &6101108449083475881
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6101108449083475876}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &3677147509884030994
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6101108449083475876}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &6101108449083475882
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6101108449083475876}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
 --- !u!114 &6496672550345548457
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,48 +119,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerInputState: 0
---- !u!114 &-8767646246911753318
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6101108449083475876}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &-5346662837639526377
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6101108449083475876}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &8446500240076052195
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -240,7 +133,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: -5346662837639526377}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -332,6 +225,18 @@ MonoBehaviour:
   m_DefaultActionMap: Player
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &4795890211778059004
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6101108449083475876}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &8373712913536383167
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Screens/InGameMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/InGameMenu.prefab
@@ -645,18 +645,14 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3816567771485690120}
-  - component: {fileID: 7233473513228747998}
-  - component: {fileID: 3816567771485690121}
-  - component: {fileID: 3816567771485690122}
   - component: {fileID: 200191516500400226}
   - component: {fileID: 3608294491291543743}
   - component: {fileID: -1407876555020766783}
   - component: {fileID: 726321752621885108}
   - component: {fileID: 4448779148451660048}
   - component: {fileID: 5710709175199979826}
-  - component: {fileID: -3103627935882755658}
-  - component: {fileID: -8032007949312757437}
   - component: {fileID: 5365354899155551352}
+  - component: {fileID: -6424729966196064276}
   m_Layer: 5
   m_Name: InGameMenu
   m_TagString: Untagged
@@ -673,7 +669,7 @@ RectTransform:
   m_GameObject: {fileID: 3816567771485690116}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4700219425850615337}
   - {fileID: 8914820262877508687}
@@ -686,71 +682,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &7233473513228747998
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!223 &3816567771485690121
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &3816567771485690122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
 --- !u!114 &200191516500400226
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -832,48 +767,6 @@ MonoBehaviour:
   enableOnHost:
   - {fileID: 453105032817049386}
   - {fileID: 4828329889223310542}
---- !u!114 &-3103627935882755658
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &-8032007949312757437
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &5365354899155551352
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -888,7 +781,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: -8032007949312757437}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -980,6 +873,18 @@ MonoBehaviour:
   m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &-6424729966196064276
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3816567771485690116}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &4828329889223310542
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Screens/LobbyScreen.prefab
+++ b/Assets/Prefabs/UI/Screens/LobbyScreen.prefab
@@ -768,18 +768,14 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3816567771485690120}
-  - component: {fileID: 7233473513228747998}
-  - component: {fileID: 3816567771485690121}
-  - component: {fileID: 3816567771485690122}
   - component: {fileID: 200191516500400226}
   - component: {fileID: -1407876555020766783}
   - component: {fileID: 726321752621885108}
   - component: {fileID: 4448779148451660048}
   - component: {fileID: 4636862844760784189}
   - component: {fileID: 5236079850471641718}
-  - component: {fileID: -6155462018252193735}
-  - component: {fileID: 8293315175576296394}
   - component: {fileID: 4811417438792839048}
+  - component: {fileID: 8009659421865929538}
   m_Layer: 5
   m_Name: LobbyScreen
   m_TagString: Untagged
@@ -796,7 +792,7 @@ RectTransform:
   m_GameObject: {fileID: 3816567771485690116}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 3002397282867464283}
   - {fileID: 6312337819570923229}
@@ -805,71 +801,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &7233473513228747998
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!223 &3816567771485690121
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &3816567771485690122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
 --- !u!114 &200191516500400226
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -950,48 +885,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   allowInputChanges: 1
   actionDelay: 0.1
---- !u!114 &-6155462018252193735
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &8293315175576296394
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3816567771485690116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &4811417438792839048
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1006,7 +899,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: 8293315175576296394}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -1086,6 +979,18 @@ MonoBehaviour:
   m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &8009659421865929538
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3816567771485690116}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &4073257875806779051
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Screens/MainMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/MainMenu.prefab
@@ -524,9 +524,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Host Game
-
-'
+  m_Text: Host Game
 --- !u!1 &1659989776656228158
 GameObject:
   m_ObjectHideFlags: 0
@@ -2289,16 +2287,12 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8543157476786906890}
-  - component: {fileID: 8543157476786906891}
-  - component: {fileID: 8543157476786906888}
-  - component: {fileID: 8543157476786906889}
   - component: {fileID: 3003935440252356647}
   - component: {fileID: 532220257149872790}
   - component: {fileID: 1266098897875397016}
   - component: {fileID: 4731608033928725337}
-  - component: {fileID: 7976886373830765123}
-  - component: {fileID: 7184331009644745124}
   - component: {fileID: -6386149883960000623}
+  - component: {fileID: 3798123373737752275}
   m_Layer: 5
   m_Name: MainMenu
   m_TagString: Untagged
@@ -2315,7 +2309,7 @@ RectTransform:
   m_GameObject: {fileID: 8543157476786906886}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2651713734637186952}
   - {fileID: 7951222681308658512}
@@ -2331,71 +2325,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &8543157476786906891
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8543157476786906886}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &8543157476786906888
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8543157476786906886}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!114 &8543157476786906889
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8543157476786906886}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!114 &3003935440252356647
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2449,48 +2382,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cursorLockMode: 0
   cursorVisible: 1
---- !u!114 &7976886373830765123
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8543157476786906886}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &7184331009644745124
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8543157476786906886}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &-6386149883960000623
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2505,7 +2396,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: 7184331009644745124}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -2585,6 +2476,18 @@ MonoBehaviour:
   m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &3798123373737752275
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8543157476786906886}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &8857033994187956672
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Screens/ServerMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/ServerMenu.prefab
@@ -88,14 +88,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4151337882126337140}
-  - component: {fileID: 4151337882126337141}
-  - component: {fileID: 4151337882126337142}
-  - component: {fileID: 4151337882126337143}
   - component: {fileID: 7084426457715482854}
   - component: {fileID: -7644575066371791825}
-  - component: {fileID: 4207797541422170155}
-  - component: {fileID: 897059647087293023}
   - component: {fileID: -4388690099473577725}
+  - component: {fileID: -785964180251839563}
   m_Layer: 5
   m_Name: ServerMenu
   m_TagString: Untagged
@@ -112,7 +108,7 @@ RectTransform:
   m_GameObject: {fileID: 4151337882126337144}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 3592822128560624846}
   - {fileID: 515622140131675340}
@@ -121,71 +117,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &4151337882126337141
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4151337882126337144}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &4151337882126337142
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4151337882126337144}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!114 &4151337882126337143
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4151337882126337144}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!114 &7084426457715482854
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -213,48 +148,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cursorLockMode: 0
   cursorVisible: 1
---- !u!114 &4207797541422170155
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4151337882126337144}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &897059647087293023
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4151337882126337144}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &-4388690099473577725
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,7 +162,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: 897059647087293023}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -349,6 +242,18 @@ MonoBehaviour:
   m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &-785964180251839563
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4151337882126337144}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &8011329247239133913
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Screens/SettingsMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/SettingsMenu.prefab
@@ -10123,14 +10123,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6637053135914170324}
-  - component: {fileID: 6637053135914170325}
-  - component: {fileID: 6637053135914170326}
-  - component: {fileID: 6637053135914170327}
   - component: {fileID: 8387962290575963714}
   - component: {fileID: 2165199262839015779}
-  - component: {fileID: 3999855679391307273}
-  - component: {fileID: 2388925180078206596}
   - component: {fileID: 1464204944664550205}
+  - component: {fileID: -1744219451164611393}
   m_Layer: 5
   m_Name: SettingsMenu
   m_TagString: Untagged
@@ -10147,7 +10143,7 @@ RectTransform:
   m_GameObject: {fileID: 6637053135914170328}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5681848051871034782}
   - {fileID: 3139743100273250435}
@@ -10155,71 +10151,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &6637053135914170325
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 1
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &6637053135914170326
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!114 &6637053135914170327
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!114 &8387962290575963714
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10248,48 +10183,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cursorLockMode: 0
   cursorVisible: 1
---- !u!114 &3999855679391307273
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!114 &2388925180078206596
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6637053135914170328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
 --- !u!114 &1464204944664550205
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10304,7 +10197,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   m_NotificationBehavior: 2
-  m_UIInputModule: {fileID: 2388925180078206596}
+  m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -10396,6 +10289,18 @@ MonoBehaviour:
   m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!225 &-1744219451164611393
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6637053135914170328}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &6674487148762431983
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/UIManager.prefab
+++ b/Assets/Prefabs/UI/UIManager.prefab
@@ -8,10 +8,15 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 576314974741431281}
+  - component: {fileID: 4198621346667254445}
   - component: {fileID: 576314974741431280}
   - component: {fileID: 7569278591705480162}
   - component: {fileID: 386998678}
+  - component: {fileID: 6400400179954856777}
+  - component: {fileID: 7559880029569120428}
+  - component: {fileID: -6247352873759180897}
+  - component: {fileID: 1957750425734041810}
+  - component: {fileID: 6623657609640478871}
   m_Layer: 0
   m_Name: UIManager
   m_TagString: Untagged
@@ -19,8 +24,8 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &576314974741431281
-Transform:
+--- !u!224 &4198621346667254445
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -28,11 +33,16 @@ Transform:
   m_GameObject: {fileID: 576314974741431287}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!114 &576314974741431280
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -46,14 +56,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   screenPrefabs:
-  - {fileID: 8543157476786906891, guid: d7e0cec9d46eff341ad598031aeba302, type: 3}
-  - {fileID: 5674224039144228346, guid: 3cf2c1b6756d7954098700a0085ef674, type: 3}
-  - {fileID: 6101108449083475881, guid: a6b724ce986920c46859b833b6f1bc83, type: 3}
-  - {fileID: 3816567771485690121, guid: 77f3d4674d5aa254aba6cd0ff623b5c3, type: 3}
-  - {fileID: 4151337882126337141, guid: 09e4cd27b3cce1849887002c2e6e0639, type: 3}
-  - {fileID: 6637053135914170325, guid: de594f0ca0c7e164fbcaade84840570f, type: 3}
-  - {fileID: 6637053135914170325, guid: 67537ab50a08bde4b8617a7d55f2563d, type: 3}
-  - {fileID: 3816567771485690121, guid: a8b22df97f8dd144aabce008ac60e871, type: 3}
+  - {fileID: 3798123373737752275, guid: d7e0cec9d46eff341ad598031aeba302, type: 3}
+  - {fileID: 1397598960152374926, guid: 3cf2c1b6756d7954098700a0085ef674, type: 3}
+  - {fileID: -5140422447409558950, guid: 67537ab50a08bde4b8617a7d55f2563d, type: 3}
+  - {fileID: 4795890211778059004, guid: a6b724ce986920c46859b833b6f1bc83, type: 3}
+  - {fileID: -6424729966196064276, guid: 77f3d4674d5aa254aba6cd0ff623b5c3, type: 3}
+  - {fileID: 8009659421865929538, guid: a8b22df97f8dd144aabce008ac60e871, type: 3}
+  - {fileID: -785964180251839563, guid: 09e4cd27b3cce1849887002c2e6e0639, type: 3}
+  - {fileID: -1744219451164611393, guid: de594f0ca0c7e164fbcaade84840570f, type: 3}
   initialScreen: 0
   maxScreenHistory: 100
 --- !u!114 &7569278591705480162
@@ -89,3 +99,106 @@ MonoBehaviour:
   - {fileID: -9155922391933593567, guid: 447bcbade0387f642bb6a6663dd979ce, type: 2}
   - {fileID: 5335082761107716713, guid: 447bcbade0387f642bb6a6663dd979ce, type: 2}
   - {fileID: -5889326568863306336, guid: 447bcbade0387f642bb6a6663dd979ce, type: 2}
+--- !u!223 &6400400179954856777
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576314974741431287}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &7559880029569120428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576314974741431287}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &-6247352873759180897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576314974741431287}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1957750425734041810
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576314974741431287}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!114 &6623657609640478871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576314974741431287}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_ActionsAsset: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_PointAction: {fileID: 3367101946890717985, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_MoveAction: {fileID: -307424754437218563, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_SubmitAction: {fileID: -5311298852430063574, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_CancelAction: {fileID: 1152416210319569963, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_LeftClickAction: {fileID: -2362483838269644402, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_MiddleClickAction: {fileID: 5278173575564425398, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_RightClickAction: {fileID: -6178336325687425428, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_ScrollWheelAction: {fileID: -7488414455339657299, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_TrackedDevicePositionAction: {fileID: -8744628688011088238, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: -8822090747999447430, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0

--- a/Assets/Scripts/UI/Actions/ChangeMouseSensitivity.cs
+++ b/Assets/Scripts/UI/Actions/ChangeMouseSensitivity.cs
@@ -20,7 +20,7 @@ namespace PropHunt.UI.Actions
         /// <summary>
         /// Power value for scaling mouse sensitivity between minimum and maximum
         /// </summary>
-        public static float powerValue = 0.75f;
+        public const float powerValue = 0.75f;
 
         /// <summary>
         /// Get the value on a slider from a given mouse sensitivity level

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -55,7 +55,7 @@ namespace PropHunt.UI
         /// <summary>
         /// Various screens to add into the scene
         /// </summary>
-        public List<Canvas> screenPrefabs = new List<Canvas>();
+        public List<CanvasGroup> screenPrefabs = new List<CanvasGroup>();
 
         /// <summary>
         /// Index of the first screen to show
@@ -134,15 +134,20 @@ namespace PropHunt.UI
                 // Set object parent to this for more organized hierarchy
                 screen.transform.SetParent(this.transform, worldPositionStays: false);
                 this.screenLookup[screenName] = screen;
+                CanvasGroup canvasGroup = screen.GetComponent<CanvasGroup>();
                 if (idx == this.initialScreen)
                 {
                     this.CurrentScreen = screenName;
                     screenSequence.AddLast(screenName);
-                    this.screenLookup[screenName].SetActive(true);
+                    canvasGroup.alpha = 1.0f;
+                    canvasGroup.interactable = true;
+                    canvasGroup.blocksRaycasts = true;
                 }
                 else
                 {
-                    this.screenLookup[screenName].SetActive(false);
+                    canvasGroup.alpha = 0.0f;
+                    canvasGroup.interactable = false;
+                    canvasGroup.blocksRaycasts = false;
                 }
             }
 
@@ -198,8 +203,15 @@ namespace PropHunt.UI
             GameObject currentlyDisplayed = this.screenLookup[this.CurrentScreen];
             GameObject newDisplay = this.screenLookup[screenName];
 
-            currentlyDisplayed.SetActive(false);
-            newDisplay.SetActive(true);
+            CanvasGroup currentCanvas = currentlyDisplayed.GetComponent<CanvasGroup>();
+            CanvasGroup nextCanvas = newDisplay.GetComponent<CanvasGroup>();
+
+            currentCanvas.alpha = 0.0f;
+            currentCanvas.interactable = false;
+            currentCanvas.blocksRaycasts = false;
+            nextCanvas.alpha = 1.0f;
+            nextCanvas.interactable = true;
+            nextCanvas.blocksRaycasts = true;
 
             ScreenChangeEventArgs changeEvent = new ScreenChangeEventArgs();
             changeEvent.oldScreen = this.CurrentScreen;

--- a/Assets/Tests/EditMode/UI/Actions/MenuControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/Actions/MenuControllerTests.cs
@@ -46,7 +46,7 @@ namespace Tests.EditMode.UI.Actions
             this.uiManager = this.menuControllerObject.AddComponent<UIManager>();
             this.menuController = this.menuControllerObject.AddComponent<MenuController>();
 
-            this.uiManager.screenPrefabs = new List<Canvas>();
+            this.uiManager.screenPrefabs = new List<CanvasGroup>();
             this.menuController.actionDelay = -10.0f;
 
             this.screenNames = new string[10];
@@ -56,7 +56,7 @@ namespace Tests.EditMode.UI.Actions
                 GameObject screen = new GameObject();
                 screen.name = this.screenNames[i];
                 screen.transform.parent = this.menuControllerObject.transform;
-                this.uiManager.screenPrefabs.Add(screen.AddComponent<Canvas>());
+                this.uiManager.screenPrefabs.Add(screen.AddComponent<CanvasGroup>());
             }
 
             Assert.Throws<System.InvalidOperationException>(() => this.uiManager.Start());

--- a/Assets/Tests/EditMode/UI/UIManagerTests.cs
+++ b/Assets/Tests/EditMode/UI/UIManagerTests.cs
@@ -68,7 +68,7 @@ namespace Tests.EditMode.UI
         [Test]
         public void UIManagerSetupWithNoScreens()
         {
-            this.uiManager.screenPrefabs = new List<Canvas>();
+            this.uiManager.screenPrefabs = new List<CanvasGroup>();
             this.uiManager.initialScreen = -1;
 
             this.uiManager.Start();
@@ -80,7 +80,7 @@ namespace Tests.EditMode.UI
         public void UIManagerDestoryDuplicate()
         {
             LogAssert.ignoreFailingMessages = true;
-            this.uiManager.screenPrefabs = new List<Canvas>();
+            this.uiManager.screenPrefabs = new List<CanvasGroup>();
             this.uiManager.initialScreen = -1;
 
             this.uiManager.Start();
@@ -98,14 +98,14 @@ namespace Tests.EditMode.UI
         [Test]
         public void UIManagerSetupSelectedNegativeInvalidScreens()
         {
-            this.uiManager.screenPrefabs = new List<Canvas>();
+            this.uiManager.screenPrefabs = new List<CanvasGroup>();
             GameObject screen = new GameObject();
-            this.uiManager.screenPrefabs.Add(screen.AddComponent<Canvas>());
+            this.uiManager.screenPrefabs.Add(screen.AddComponent<CanvasGroup>());
             this.uiManager.initialScreen = -10;
 
             Assert.Throws<System.InvalidOperationException>(() => this.uiManager.Start());
 
-            foreach (Canvas canvasObject in this.uiManager.screenPrefabs)
+            foreach (CanvasGroup canvasObject in this.uiManager.screenPrefabs)
             {
                 GameObject.DestroyImmediate(canvasObject.gameObject);
             }
@@ -118,14 +118,14 @@ namespace Tests.EditMode.UI
         [Test]
         public void UIManagerSetupSelectedOutOfRangeInvalidScreens()
         {
-            this.uiManager.screenPrefabs = new List<Canvas>();
+            this.uiManager.screenPrefabs = new List<CanvasGroup>();
             GameObject screen = new GameObject();
-            this.uiManager.screenPrefabs.Add(screen.AddComponent<Canvas>());
+            this.uiManager.screenPrefabs.Add(screen.AddComponent<CanvasGroup>());
             this.uiManager.initialScreen = 10;
 
             Assert.Throws<System.InvalidOperationException>(() => this.uiManager.Start());
 
-            foreach (Canvas canvasObject in this.uiManager.screenPrefabs)
+            foreach (CanvasGroup canvasObject in this.uiManager.screenPrefabs)
             {
                 GameObject.DestroyImmediate(canvasObject.gameObject);
             }
@@ -138,13 +138,13 @@ namespace Tests.EditMode.UI
         [Test]
         public void UIManagerLoadScreenOnEnable()
         {
-            this.uiManager.screenPrefabs = new List<Canvas>();
+            this.uiManager.screenPrefabs = new List<CanvasGroup>();
             GameObject screen1 = new GameObject();
             screen1.name = "Screen 1";
             GameObject screen2 = new GameObject();
             screen2.name = "Screen 2";
-            this.uiManager.screenPrefabs.Add(screen1.AddComponent<Canvas>());
-            this.uiManager.screenPrefabs.Add(screen2.AddComponent<Canvas>());
+            this.uiManager.screenPrefabs.Add(screen1.AddComponent<CanvasGroup>());
+            this.uiManager.screenPrefabs.Add(screen2.AddComponent<CanvasGroup>());
 
             this.uiManager.initialScreen = 0;
 
@@ -169,16 +169,16 @@ namespace Tests.EditMode.UI
         [Test]
         public void UIManagerSetupCorrectlyAndSetScreens()
         {
-            this.uiManager.screenPrefabs = new List<Canvas>();
+            this.uiManager.screenPrefabs = new List<CanvasGroup>();
             int totalScreens = 10;
-            GameObject[] screens = new GameObject[totalScreens];
+            GameObject[] screenPrefabs = new GameObject[totalScreens];
             string[] screenNames = new string[totalScreens];
             for (int screenIdx = 0; screenIdx < totalScreens; screenIdx++)
             {
-                screens[screenIdx] = new GameObject();
-                screens[screenIdx].name = "Screen" + screenIdx.ToString();
-                screenNames[screenIdx] = screens[screenIdx].name;
-                this.uiManager.screenPrefabs.Add(screens[screenIdx].AddComponent<Canvas>());
+                screenPrefabs[screenIdx] = new GameObject();
+                screenPrefabs[screenIdx].name = "Screen" + screenIdx.ToString();
+                screenNames[screenIdx] = screenPrefabs[screenIdx].name;
+                this.uiManager.screenPrefabs.Add(screenPrefabs[screenIdx].AddComponent<CanvasGroup>());
             }
             this.uiManager.initialScreen = 2;
 
@@ -219,7 +219,7 @@ namespace Tests.EditMode.UI
             Assert.IsTrue(this.screenChangeEvents == 3);
             Assert.IsTrue(this.currentScreen == screenNames[2]);
 
-            // Add screens until the history overflows
+            // Add screenPrefabs until the history overflows
             for (int i = 0; i < uiManager.maxScreenHistory; i++)
             {
                 UIManager.RequestNewScreen(this, screenNames[i % 2]);
@@ -233,12 +233,12 @@ namespace Tests.EditMode.UI
             Assert.IsTrue(this.currentScreen == beforePrevious);
 
             // Cleanup objects created by test
-            foreach (Canvas canvasObject in this.uiManager.screenPrefabs)
+            foreach (CanvasGroup canvasObject in this.uiManager.screenPrefabs)
             {
                 GameObject.DestroyImmediate(canvasObject.gameObject);
             }
 
-            foreach (GameObject screen in screens)
+            foreach (GameObject screen in screenPrefabs)
             {
                 GameObject.DestroyImmediate(screen);
             }


### PR DESCRIPTION
# Description

Changed screens to use Canvas Group as opposed to a whole canvas.

This helps with some interactions using the new input system and allow for more future flexibility. 

# How Has This Been Tested?

This has been tested locally and does not effect existing unit tests using the UI. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
