### PR TITLE
Add files from old semver branch

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,33 @@
+name: Update Unity project semantic versioning
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create:
+    name: Update semver
+    runs-on: ubuntu-latest
+
+    steps:
+      # You must ALWAYS checkout your repo so that actions in the workflow can use it.
+      - name: Checkout 
+        uses: actions/checkout@v2
+
+      - name: Find ProjectSettings.asset & increment its bundleVersion number
+        uses: AlexHolderDeveloper/UnityAutomatedSemver@v1.0.1
+        id: semver-update
+        with:
+          semver-update-type: 'patch' # version number: "major.minor.patch"
+
+      # Validate that the number has been incremented correctly.
+      - name: Get the new semver number
+        run: echo "The new semver number for this Unity project is ${{ steps.semver-update.outputs.semver-number }}"
+
+      # Commit & push the updated semver number back into the repo. Yes, you have to fetch & pull in your local workstation after this step is done.
+      - name: Push changed files back to repo
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Updated semver via automated action."
+          commit_options: '--no-verify --signoff'

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.1
+  bundleVersion: 0.0.0
   preloadedAssets:
   - {fileID: 11400000, guid: b90dafd9da192a041b170ef2a3ab1dc7, type: 2}
   metroInputSource: 0


### PR DESCRIPTION
# Description

Added a simple Github workflow
This PR replaces #90, but has only signed commits

# How Has This Been Tested?
Manual workflow test ran successfully. If semantic versioning used only 2 numbers (e.g. 1.0 vs 1.0.0), the workflow will fail. Solution: use three-number versioning.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~ n/a
- [x] My changes generate no new warnings
